### PR TITLE
Build gradle netrc support mac

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ def getTokenFromEnv() {
 }
 
 def getTokenFromNetrc() {
-    def contentList = [:]
+    def credentials = [:]
     def netrcPath = System.getProperty("user.home") + '/.netrc';
     def content = new File(netrcPath);
     def lastMachine = null;
@@ -29,16 +29,21 @@ def getTokenFromNetrc() {
                     switch (it[0]) {
                         case 'machine':
                             lastMachine = it[1];
-                            contentList.put(lastMachine, [:]);
+                            credentials.put(lastMachine, [:]);
                             break
                         default:
-                            contentList.
+                            credentials.
                             "$lastMachine".put(it[0], it[1])
                     }
                 }
             };
     }
-    return contentList["api.mapbox.com"]["password"];
+
+    if (!credentials.containsKey("api.mapbox.com")) {
+        return null;
+    }
+
+    return credentials["api.mapbox.com"]["password"];
 }
 
 def getToken() {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,61 @@
+import org.gradle.internal.os.OperatingSystem
+
 group 'com.mapbox.mapboxgl'
-version '1.0-SNAPSHOT'
+version '1.1-SNAPSHOT'
+
+def getTokenFromEnv() {
+    def token = System.getenv('SDK_REGISTRY_TOKEN');
+    if (token == null || token.empty) {
+        throw new Exception("SDK Registry token is null. See README.md for more information.")
+    }
+    return token;
+}
+
+def getTokenFromNetrc() {
+    def contentList = [:]
+    def netrcPath = System.getProperty("user.home") + '/.netrc';
+    def content = new File(netrcPath);
+    def lastMachine = null;
+
+    if (!content.exists()) {
+        return null;
+    }
+    content.eachLine {
+        it ->
+            it.split().collect {
+                it.trim();
+            }.with {
+                if (it.size() > 1) {
+                    switch (it[0]) {
+                        case 'machine':
+                            lastMachine = it[1];
+                            contentList.put(lastMachine, [:]);
+                            break
+                        default:
+                            contentList.
+                            "$lastMachine".put(it[0], it[1])
+                    }
+                }
+            };
+    }
+    return contentList["api.mapbox.com"]["password"];
+}
+
+def getToken() {
+    if (OperatingSystem.current().isMacOsX()) {
+        final netrcToken = getTokenFromNetrc();
+        if (netrcToken != null) {
+            return netrcToken;
+        } else {
+            return getTokenFromEnv();
+        }
+    } else {
+        return getTokenFromEnv();
+    }
+}
+
+def token = getToken();
+
 
 buildscript {
     repositories {
@@ -13,10 +69,7 @@ buildscript {
 }
 
 rootProject.allprojects {
-    def token = System.getenv('SDK_REGISTRY_TOKEN')
-    if (token == null || token.empty) {
-        throw new Exception("SDK Registry token is null. See README.md for more information.")
-    }
+
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
adding netrc support to build.gradle, Developers ( mac users ) can now save tokens once in netrc and **use them on both platforms android and ios without adding new key in env.**
If the token is not in the netrc (or maybe netrc not exist), it reads it from the env just like before