### PR TITLE
Fix for SDK token use in Gradle builds (#604)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,18 @@ An alternative method to provide access tokens that was required until the v0.7 
 
 ### SDK Download token
 
-You must also [configure a secret access token having the Download: read
-scope][https://docs.mapbox.com/ios/maps/guides/install/]. If this configuration
-is not present, an error like the following appears during the iOS build.
+You must also [configure a secret access token having the _Download: read
+scope_ ([Android][https://docs.mapbox.com/android/maps/guides/install/] [iOS][https://docs.mapbox.com/ios/maps/guides/install/]). If this configuration
+is not present, an error like the following appears during build time:
 
+***Android***
+```
+* What went wrong:
+A problem occurred evaluating project ':mapbox_gl'.
+> SDK Registry token is null. See README.md for more information.
+```
+
+***iOS***
 ```
 [!] Error installing Mapbox-iOS-SDK
 curl: (22) The requested URL returned error: 401 Unauthorized

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 rootProject.allprojects {
-    def token = System.getenv('SDK_REGISTRY_TOKEN')
+    def token = project.property('MAPBOX_DOWNLOADS_TOKEN')
     if (token == null || token.empty) {
         throw new Exception("SDK Registry token is null. See README.md for more information.")
     }


### PR DESCRIPTION
Updated build.gradle to reference gradle.properties, and to use MAPBOX_DOWNLOADS_TOKEN rather than SDK_REGISTRY_TOKEN. This makes it consistent with the Android installation instructions.

Also updated documentation to note this step as it's no longer iOS specific.