### PR TITLE
Add onStyleImageMissing event

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -7,6 +7,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
     
     private var registrar: FlutterPluginRegistrar
     private var channel: FlutterMethodChannel?
+    private var emptyImage: UIImage? = nil
     
     private var mapView: MGLMapView
     private var isMapReady = false
@@ -984,6 +985,27 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         if let channel = channel {
             channel.invokeMethod("camera#onIdle", arguments: arguments);
         }
+    }
+
+    func mapView(_ mapView: MGLMapView, didFailToLoadImage imageName: String) -> UIImage? { 
+        if let channel = channel {
+            channel.invokeMethod("map#styleImageMissing", arguments: [
+                "imageName": imageName
+            ]);
+        }
+        // We need to return any image so style.setImage can work in asynchronous way
+        return blankImage()
+    }
+
+    // Generates empty, 1x1 image
+    func blankImage() -> UIImage {
+        guard emptyImage != nil else {
+            UIGraphicsBeginImageContextWithOptions(.init(width: 1, height: 1), false, 1)
+            let blank = UIGraphicsGetImageFromCurrentImageContext();
+            UIGraphicsEndImageContext();
+            return blank!;
+        }
+        return emptyImage!
     }
     
     /*

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -10,6 +10,7 @@ typedef void OnMapLongClickCallback(Point<double> point, LatLng coordinates);
 typedef void OnAttributionClickCallback();
 
 typedef void OnStyleLoadedCallback();
+typedef void OnStyleImageMissingCallback(String imageName);
 
 typedef void OnUserLocationUpdated(UserLocation location);
 
@@ -45,6 +46,7 @@ class MapboxMapController extends ChangeNotifier {
       this.onCameraTrackingChanged,
       this.onMapIdle,
       this.onUserLocationUpdated,
+      this.onStyleImageMissing,
       this.onCameraIdle}) {
     _cameraPosition = initialCameraPosition;
 
@@ -160,11 +162,15 @@ class MapboxMapController extends ChangeNotifier {
         .add((location) {
       onUserLocationUpdated?.call(location);
     });
+    MapboxGlPlatform.getInstance(_id).onStyleImageMissing.add((imageName) {
+      onStyleImageMissing?.call(imageName);
+    });
   }
 
   static MapboxMapController init(int id, CameraPosition initialCameraPosition,
       {OnStyleLoadedCallback? onStyleLoadedCallback,
       OnMapClickCallback? onMapClick,
+      OnStyleImageMissingCallback? onStyleImageMissing,
       OnUserLocationUpdated? onUserLocationUpdated,
       OnMapLongClickCallback? onMapLongClick,
       OnAttributionClickCallback? onAttributionClick,
@@ -181,6 +187,7 @@ class MapboxMapController extends ChangeNotifier {
         onCameraTrackingDismissed: onCameraTrackingDismissed,
         onCameraTrackingChanged: onCameraTrackingChanged,
         onCameraIdle: onCameraIdle,
+        onStyleImageMissing: onStyleImageMissing,
         onMapIdle: onMapIdle);
   }
 
@@ -189,6 +196,7 @@ class MapboxMapController extends ChangeNotifier {
   }
 
   final OnStyleLoadedCallback? onStyleLoadedCallback;
+  final OnStyleImageMissingCallback? onStyleImageMissing;
 
   final OnMapClickCallback? onMapClick;
   final OnMapLongClickCallback? onMapLongClick;

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -35,6 +35,7 @@ class MapboxMap extends StatefulWidget {
     this.onMapClick,
     this.onUserLocationUpdated,
     this.onMapLongClick,
+    this.onStyleImageMissing,
     this.onAttributionClick,
     this.onCameraTrackingDismissed,
     this.onCameraTrackingChanged,
@@ -172,6 +173,7 @@ class MapboxMap extends StatefulWidget {
 
   final OnMapClickCallback? onMapClick;
   final OnMapClickCallback? onMapLongClick;
+  final OnStyleImageMissingCallback? onStyleImageMissing;
 
   final OnAttributionClickCallback? onAttributionClick;
 
@@ -276,6 +278,7 @@ class _MapboxMapState extends State<MapboxMap> {
       onCameraTrackingChanged: widget.onCameraTrackingChanged,
       onCameraIdle: widget.onCameraIdle,
       onMapIdle: widget.onMapIdle,
+      onStyleImageMissing: widget.onStyleImageMissing,
     );
     await MapboxMapController.initPlatform(id);
     _controller.complete(controller);

--- a/mapbox_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
+++ b/mapbox_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
@@ -57,6 +57,8 @@ abstract class MapboxGlPlatform {
 
   final onMapIdlePlatform = ArgumentCallbacks<void>();
 
+  final onStyleImageMissing = ArgumentCallbacks<String>();
+
   final onUserLocationUpdatedPlatform = ArgumentCallbacks<UserLocation>();
 
   Future<void> initPlatform(int id) async {

--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -109,6 +109,10 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
             timestamp: DateTime.fromMillisecondsSinceEpoch(
                 userLocation['timestamp'])));
         break;
+      case 'map#styleImageMissing':
+        final String imageName = call.arguments['imageName'];
+        onStyleImageMissing(imageName);
+        break;
       default:
         throw MissingPluginException();
     }

--- a/mapbox_gl_web/lib/src/feature_manager/symbol_manager.dart
+++ b/mapbox_gl_web/lib/src/feature_manager/symbol_manager.dart
@@ -1,10 +1,12 @@
 part of mapbox_gl_web;
 
 class SymbolManager extends FeatureManager<SymbolOptions> {
-  SymbolManager({
-    required MapboxMap map,
-    ArgumentCallbacks<String>? onTap,
-  }) : super(
+  ArgumentCallbacks<String>? onStyleImageMissing;
+  SymbolManager(
+      {required MapboxMap map,
+      ArgumentCallbacks<String>? onTap,
+      this.onStyleImageMissing})
+      : super(
           sourceId: 'symbol_source',
           layerId: 'symbol_layer',
           map: map,
@@ -50,21 +52,6 @@ class SymbolManager extends FeatureManager<SymbolOptions> {
         'text-halo-width': ['get', 'textHaloWidth'],
         'text-halo-blur': ['get', 'textHaloBlur'],
       }
-    });
-
-    map.on('styleimagemissing', (event) {
-      if (event.id == '') {
-        return;
-      }
-      var density = context['window'].devicePixelRatio ?? 1;
-      var imagePath = density == 1
-          ? '/assets/assets/symbols/custom-icon.png'
-          : '/assets/assets/symbols/$density.0x/custom-icon.png';
-      map.loadImage(imagePath, (error, image) {
-        if (error != null) throw error;
-        if (!map.hasImage(event.id))
-          map.addImage(event.id, image, {'pixelRatio': density});
-      });
     });
   }
 


### PR DESCRIPTION
This PR adds onStyleImageMissing event to MapBox constructor, which implements following platform related events:

* `onStyleImageMissing` event from Android SDK (see [example](https://docs.mapbox.com/android/maps/examples/missing-icon/) and [reference](https://docs.mapbox.com/android/maps/api/9.6.1/com/mapbox/mapboxsdk/maps/MapView.OnStyleImageMissingListener.html))
* `onstyleimagemissing` from Web SDK (see [example](https://docs.mapbox.com/android/maps/examples/missing-icon/))
* `didFailToLoadImage` from iOS SDK (see [PR](https://github.com/mapbox/mapbox-gl-native/pull/14302), not documented yet)