### PR TITLE
[Example] Remove layer before adding layer if layer is added in place source example

### DIFF
--- a/example/lib/place_source.dart
+++ b/example/lib/place_source.dart
@@ -72,7 +72,7 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
     if(layerAdded) {
       removeLayer(imageLayerId);
     }
-    layerAdded = true;
+    setState(() => layerAdded = true);
     return controller.addImageLayer(imageLayerId, imageSourceId);
   }
 
@@ -81,12 +81,12 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
     if(layerAdded) {
       removeLayer(imageLayerId);
     }
-    layerAdded = true;
+    setState(() => layerAdded = true);
     return controller.addImageLayerBelow(imageLayerId, imageSourceId, belowLayerId);
   }
 
   Future<void> removeLayer(String imageLayerId) {
-    layerAdded = false;
+    setState(() => layerAdded = false);
     return controller.removeLayer(imageLayerId);
   }
 

--- a/example/lib/place_source.dart
+++ b/example/lib/place_source.dart
@@ -35,6 +35,7 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
   static const LAYER_ID = 'sydney_layer';
 
   bool sourceAdded = false;
+  bool layerAdded = false;
   late MapboxMapController controller;
 
   void _onMapCreated(MapboxMapController controller) {
@@ -68,16 +69,24 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
   }
 
   Future<void> addLayer(String imageLayerId, String imageSourceId) {
+    if(layerAdded) {
+      removeLayer(imageLayerId);
+    }
+    layerAdded = true;
     return controller.addImageLayer(imageLayerId, imageSourceId);
   }
 
   Future<void> addLayerBelow(
       String imageLayerId, String imageSourceId, String belowLayerId) {
-    return controller.addImageLayerBelow(
-        imageLayerId, imageSourceId, belowLayerId);
+    if(layerAdded) {
+      removeLayer(imageLayerId);
+    }
+    layerAdded = true;
+    return controller.addImageLayerBelow(imageLayerId, imageSourceId, belowLayerId);
   }
 
   Future<void> removeLayer(String imageLayerId) {
+    layerAdded = false;
     return controller.removeLayer(imageLayerId);
   }
 
@@ -106,55 +115,50 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: <Widget>[
-                Row(
+                Column(
                   children: <Widget>[
-                    Column(
-                      children: <Widget>[
-                        TextButton(
-                          child: const Text('Add source (asset image)'),
-                          onPressed: sourceAdded
-                              ? null
-                              : () {
-                                  addImageSourceFromAsset(
-                                          SOURCE_ID, 'assets/sydney.png')
-                                      .then((value) {
-                                    setState(() => sourceAdded = true);
-                                  });
-                                },
-                        ),
-                        TextButton(
-                          child: const Text('Remove source (asset image)'),
-                          onPressed: sourceAdded
-                              ? () async {
-                                  await removeLayer(LAYER_ID);
-                                  removeImageSource(SOURCE_ID).then((value) {
-                                    setState(() => sourceAdded = false);
-                                  });
-                                }
-                              : null,
-                        ),
-                        TextButton(
-                          child: const Text('Show layer'),
-                          onPressed: sourceAdded
-                              ? () => addLayer(LAYER_ID, SOURCE_ID)
-                              : null,
-                        ),
-                        TextButton(
-                          child: const Text('Show layer below water'),
-                          onPressed: sourceAdded
-                              ? () =>
-                                  addLayerBelow(LAYER_ID, SOURCE_ID, 'water')
-                              : null,
-                        ),
-                        TextButton(
-                          child: const Text('Hide layer'),
-                          onPressed:
-                              sourceAdded ? () => removeLayer(LAYER_ID) : null,
-                        ),
-                      ],
+                    TextButton(
+                      child: const Text('Add source (asset image)'),
+                      onPressed: sourceAdded
+                          ? null
+                          : () {
+                              addImageSourceFromAsset(
+                                      SOURCE_ID, 'assets/sydney.png')
+                                  .then((value) {
+                                setState(() => sourceAdded = true);
+                              });
+                            },
+                    ),
+                    TextButton(
+                      child: const Text('Remove source (asset image)'),
+                      onPressed: sourceAdded
+                          ? () async {
+                              await removeLayer(LAYER_ID);
+                              removeImageSource(SOURCE_ID).then((value) {
+                                setState(() => sourceAdded = false);
+                              });
+                            }
+                          : null,
+                    ),
+                    TextButton(
+                      child: const Text('Show layer'),
+                      onPressed: sourceAdded
+                          ? () => addLayer(LAYER_ID, SOURCE_ID)
+                          : null,
+                    ),
+                    TextButton(
+                      child: const Text('Show layer below water'),
+                      onPressed: sourceAdded
+                          ? () => addLayerBelow(LAYER_ID, SOURCE_ID, 'water')
+                          : null,
+                    ),
+                    TextButton(
+                      child: const Text('Hide layer'),
+                      onPressed:
+                          sourceAdded ? () => removeLayer(LAYER_ID) : null,
                     ),
                   ],
-                )
+                ),
               ],
             ),
           ),


### PR DESCRIPTION
This PR adds a variable `layerAdded` to record the current status of imageLayer and will remove it before adding it, so that `show Layer` and `show layer below water ` act normally.
Also removes the redundant `Row` widget.

| Before | After |
| ---- | ---- |
|<video src="https://user-images.githubusercontent.com/8577318/141934443-110d99b2-49e5-483c-9149-eaf51158032f.mp4" width = 250/>|<video src="https://user-images.githubusercontent.com/8577318/141934091-9c3ef7b7-3cb5-40f6-a5ab-ba1a6d796bcd.mp4" width = 250/>


|
