### PR TITLE
[android] speed property is null when onUserLocationUpdated is called

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -389,6 +389,7 @@ final class MapboxMapController
 
     final Map<String, Object> userLocation = new HashMap<>(6);
     userLocation.put("position", new double[]{location.getLatitude(), location.getLongitude()});
+    userLocation.put("speed", location.getSpeed());
     userLocation.put("altitude", location.getAltitude());
     userLocation.put("bearing", location.getBearing());
     userLocation.put("horizontalAccuracy", location.getAccuracy());


### PR DESCRIPTION
This PR closes #761.
In Android when onUserLocationUpdated is called, the speed property is null.