### PR TITLE
Handle line color and geometry

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/LineController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/LineController.java
@@ -16,7 +16,7 @@ import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.annotation.Line;
 import com.mapbox.mapboxsdk.plugins.annotation.LineManager;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
+import android.graphics.Color;
 
 /**
  * Controller of a single Line on the map.
@@ -59,7 +59,7 @@ class LineController implements LineOptionsSink {
   
   @Override
   public void setLineColor(String lineColor) {
-    line.setLineColor(ColorUtils.rgbaToColor(lineColor));
+    line.setLineColor(Color.parseColor(lineColor));
   }
 
   @Override

--- a/example/lib/line.dart
+++ b/example/lib/line.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:mapbox_gl/mapbox_gl.dart';

--- a/example/lib/line.dart
+++ b/example/lib/line.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:mapbox_gl/mapbox_gl.dart';
@@ -46,26 +47,20 @@ class LineBodyState extends State<LineBody> {
     super.dispose();
   }
 
-  void _onLineTapped(Line line) {
-    if (_selectedLine != null) {
-      _updateSelectedLine(
-        const LineOptions(
-          lineWidth: 28.0,
-        ),
-      );
-    }
+  _onLineTapped(Line line) async {
+    await _updateSelectedLine(
+      LineOptions(lineColor: "#ff0000"),
+    );
     setState(() {
       _selectedLine = line;
     });
-    _updateSelectedLine(
-      LineOptions(
-          // linecolor: ,
-          ),
+    await _updateSelectedLine(
+      LineOptions(lineColor: "#ffe100"),
     );
   }
 
-  void _updateSelectedLine(LineOptions changes) {
-    controller!.updateLine(_selectedLine!, changes);
+  _updateSelectedLine(LineOptions changes) async {
+    if (_selectedLine != null) controller!.updateLine(_selectedLine!, changes);
   }
 
   void _add() {
@@ -87,6 +82,17 @@ class LineBodyState extends State<LineBody> {
     });
   }
 
+  _move() async {
+    final currentStart = _selectedLine!.options.geometry![0];
+    final currentEnd = _selectedLine!.options.geometry![1];
+    final end =
+        LatLng(currentEnd.latitude + 0.001, currentEnd.longitude + 0.001);
+    final start =
+        LatLng(currentStart.latitude - 0.001, currentStart.longitude - 0.001);
+    await controller!
+        .updateLine(_selectedLine!, LineOptions(geometry: [start, end]));
+  }
+
   void _remove() {
     controller!.removeLine(_selectedLine!);
     setState(() {
@@ -102,7 +108,7 @@ class LineBodyState extends State<LineBody> {
       current = 1.0;
     }
 
-    _updateSelectedLine(
+    await _updateSelectedLine(
       LineOptions(lineOpacity: current < 0.1 ? 1.0 : current * 0.75),
     );
   }
@@ -113,13 +119,13 @@ class LineBodyState extends State<LineBody> {
       // default value
       current = 1.0;
     }
-    _updateSelectedLine(
+    await _updateSelectedLine(
       LineOptions(lineOpacity: current == 0.0 ? 1.0 : 0.0),
     );
   }
 
-  void onStyleLoadedCallback() {
-    controller!.addLine(
+  _onStyleLoadedCallback() async {
+    await controller!.addLine(
       LineOptions(
         geometry: [LatLng(37.4220, -122.0841), LatLng(37.4240, -122.0941)],
         lineColor: "#ff0000",
@@ -137,12 +143,11 @@ class LineBodyState extends State<LineBody> {
       children: <Widget>[
         Center(
           child: SizedBox(
-            width: 300.0,
-            height: 200.0,
+            height: 400.0,
             child: MapboxMap(
               accessToken: MapsDemo.ACCESS_TOKEN,
               onMapCreated: _onMapCreated,
-              onStyleLoadedCallback: onStyleLoadedCallback,
+              onStyleLoadedCallback: _onStyleLoadedCallback,
               initialCameraPosition: const CameraPosition(
                 target: LatLng(-33.852, 151.211),
                 zoom: 11.0,
@@ -155,9 +160,9 @@ class LineBodyState extends State<LineBody> {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: <Widget>[
-                Row(
+                Column(
                   children: <Widget>[
-                    Column(
+                    Row(
                       children: <Widget>[
                         TextButton(
                           child: const Text('add'),
@@ -167,9 +172,17 @@ class LineBodyState extends State<LineBody> {
                           child: const Text('remove'),
                           onPressed: (_selectedLine == null) ? null : _remove,
                         ),
+                        TextButton(
+                          child: const Text('move'),
+                          onPressed: (_selectedLine == null)
+                              ? null
+                              : () async {
+                                  await _move();
+                                },
+                        ),
                       ],
                     ),
-                    Column(
+                    Row(
                       children: <Widget>[
                         TextButton(
                           child: const Text('change alpha'),
@@ -196,7 +209,7 @@ class LineBodyState extends State<LineBody> {
                       ],
                     ),
                   ],
-                )
+                ),
               ],
             ),
           ),

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -325,13 +325,25 @@ class Convert {
         if let draggable = options["draggable"] as? Bool {
             delegate.isDraggable = draggable
         }
+    }
     
-        if let geometry = options["geometry"] as? [[Double]], geometry.count > 0 {
-            var coordinates: [CLLocationCoordinate2D] = []
+    class func getCoordinates(options: Any?)  -> [CLLocationCoordinate2D] {
+        var coordinates: [CLLocationCoordinate2D] = []
+        
+        if let options = options as? [String: Any],
+            let geometry = options["geometry"] as? [[Double]], geometry.count > 0 {
             for coordinate in geometry {
                 coordinates.append(CLLocationCoordinate2DMake(coordinate[0], coordinate[1]))
             }
+        }
+        return coordinates
+    }
+    
+    class func interpretGeometryUpdate(options: Any?, delegate: MGLLineStyleAnnotation) {
+        if let options = options as? [String: Any],
+           let geometry = options["geometry"] as? [[Double]], geometry.count > 0 {
             if let feature = delegate.feature as? MGLPolylineFeature {
+                var coordinates = Convert.getCoordinates(options: options)
                 feature.setCoordinates(&coordinates, count: UInt(coordinates.count))
             }
         }

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -325,6 +325,16 @@ class Convert {
         if let draggable = options["draggable"] as? Bool {
             delegate.isDraggable = draggable
         }
+    
+        if let geometry = options["geometry"] as? [[Double]], geometry.count > 0 {
+            var coordinates: [CLLocationCoordinate2D] = []
+            for coordinate in geometry {
+                coordinates.append(CLLocationCoordinate2DMake(coordinate[0], coordinate[1]))
+            }
+            if let feature = delegate.feature as? MGLPolylineFeature {
+                feature.setCoordinates(&coordinates, count: UInt(coordinates.count))
+            }
+        }
     }
     
     class func interpretFillOptions(options: Any?, delegate: MGLPolygonStyleAnnotation) {

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -428,16 +428,10 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         case "line#add":
             guard let lineAnnotationController = lineAnnotationController else { return }
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
-            // Parse geometry
-            if let options = arguments["options"] as? [String: Any],
-                let geometry = options["geometry"] as? [[Double]] {
-                // Convert geometry to coordinate and create a line.
-                var lineCoordinates: [CLLocationCoordinate2D] = []
-                for coordinate in geometry {
-                    lineCoordinates.append(CLLocationCoordinate2DMake(coordinate[0], coordinate[1]))
-                }
-                let line = MGLLineStyleAnnotation(coordinates: lineCoordinates, count: UInt(lineCoordinates.count))
-                Convert.interpretLineOptions(options: arguments["options"], delegate: line)
+            
+            if let options = arguments["options"] as? [String: Any] {
+                let line = MGLLineStyleAnnotation()
+                Convert.interpretLineOptions(options: options, delegate: line)
                 lineAnnotationController.addStyleAnnotation(line)
                 lineAnnotationController.annotationsInteractionEnabled = annotationConsumeTapEvents.contains("AnnotationType.line")
                 result(line.identifier)
@@ -448,23 +442,15 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         case "line#addAll":
             guard let lineAnnotationController = lineAnnotationController else { return }
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
-            // Parse geometry
+            
             var identifier: String? = nil
             if let allOptions = arguments["options"] as? [[String: Any]]{
                 var lines: [MGLLineStyleAnnotation] = [];
 
                 for options in allOptions {
-                    if let geometry = options["geometry"] as? [[Double]] {
-                        guard geometry.count > 0 else { break }
-                        // Convert geometry to coordinate and create a line.
-                        var lineCoordinates: [CLLocationCoordinate2D] = []
-                        for coordinate in geometry {
-                            lineCoordinates.append(CLLocationCoordinate2DMake(coordinate[0], coordinate[1]))
-                        }
-                        let line = MGLLineStyleAnnotation(coordinates: lineCoordinates, count: UInt(lineCoordinates.count))
-                        Convert.interpretLineOptions(options: options, delegate: line)
-                        lines.append(line)
-                    }
+                    let line = MGLLineStyleAnnotation()
+                    Convert.interpretLineOptions(options: options, delegate: line)
+                    lines.append(line)
                 }
                 if !lines.isEmpty {
                     lineAnnotationController.addStyleAnnotations(lines)


### PR DESCRIPTION
Solves https://github.com/flutter-mapbox-gl/maps/issues/448 by using Color.parseColor to correctly support hex color strings for lines

Solves https://github.com/flutter-mapbox-gl/maps/issues/762 by interpreting and setting geometry on the line, allowing to programmatically move lines