### PR TITLE
Pass click details to feature tapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.15.0, Unreleased
+### Breaking changes
+* callbacks added to onFeatureTapped will now also get the position (`Point<double>`) and the location (`LatLng`) of the click passed when called [#798](https://github.com/flutter-mapbox-gl/maps/pull/798) 
+
+
 ## 0.14.0, November 13, 2021
 * Remove memory leaks by disposing internal components [#706](https://github.com/tobrun/flutter-mapbox-gl/pull/706) 
 * Improved annotation click order [#748](https://github.com/tobrun/flutter-mapbox-gl/pull/748)

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -1300,16 +1300,16 @@ final class MapboxMapController
       pointf.y + 10
     );
     Feature feature = firstFeatureOnLayers(rectF);
+    arguments.put("x", pointf.x);
+    arguments.put("y", pointf.y);
+    arguments.put("lng", point.getLongitude());
+    arguments.put("lat", point.getLatitude());
     if(feature != null){
       final Map<String, Object> arguments = new HashMap<>(1);
-      arguments.put("featureId", feature.id());
+      arguments.put("id", feature.id());
       methodChannel.invokeMethod("feature#onTap", arguments);
     } else { 
       final Map<String, Object> arguments = new HashMap<>(5);
-      arguments.put("x", pointf.x);
-      arguments.put("y", pointf.y);
-      arguments.put("lng", point.getLongitude());
-      arguments.put("lat", point.getLatitude());
       methodChannel.invokeMethod("map#onMapClick", arguments);
     }
     return true;

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -1300,16 +1300,15 @@ final class MapboxMapController
       pointf.y + 10
     );
     Feature feature = firstFeatureOnLayers(rectF);
+    final Map<String, Object> arguments = new HashMap<>();
     arguments.put("x", pointf.x);
     arguments.put("y", pointf.y);
     arguments.put("lng", point.getLongitude());
     arguments.put("lat", point.getLatitude());
     if(feature != null){
-      final Map<String, Object> arguments = new HashMap<>(1);
       arguments.put("id", feature.id());
       methodChannel.invokeMethod("feature#onTap", arguments);
     } else { 
-      final Map<String, Object> arguments = new HashMap<>(5);
       methodChannel.invokeMethod("map#onMapClick", arguments);
     }
     return true;

--- a/example/lib/layer.dart
+++ b/example/lib/layer.dart
@@ -45,7 +45,7 @@ class LayerState extends State {
     controller.onFeatureTapped.add(onFeatureTap);
   }
 
-  void onFeatureTap(dynamic featureId) {
+  void onFeatureTap(dynamic featureId, Point<double> point, LatLng latLng) {
     final snackBar = SnackBar(
       content: Text(
         'Tapped feature with id $featureId',

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -831,7 +831,11 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
 
         if let feature = firstFeatureOnLayers(at: point), let id = feature.identifier {
             channel?.invokeMethod("feature#onTap", arguments: [
-                        "featureId": id
+                        "id": id
+                        "x": point.x,
+                        "y": point.y,
+                        "lng": coordinate.longitude,
+                        "lat": coordinate.latitude,
             ])
         } else {
             let coordinate = mapView.convert(point, toCoordinateFrom: mapView)

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -828,17 +828,17 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
     @objc @IBAction func handleMapTap(sender: UITapGestureRecognizer) {
         // Get the CGPoint where the user tapped.
         let point = sender.location(in: mapView)
+        let coordinate = mapView.convert(point, toCoordinateFrom: mapView)
 
         if let feature = firstFeatureOnLayers(at: point), let id = feature.identifier {
             channel?.invokeMethod("feature#onTap", arguments: [
-                        "id": id
+                        "id": id,
                         "x": point.x,
                         "y": point.y,
                         "lng": coordinate.longitude,
                         "lat": coordinate.latitude,
             ])
         } else {
-            let coordinate = mapView.convert(point, toCoordinateFrom: mapView)
             channel?.invokeMethod("map#onMapClick", arguments: [
                         "x": point.x,
                         "y": point.y,

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -5,6 +5,10 @@
 part of mapbox_gl;
 
 typedef void OnMapClickCallback(Point<double> point, LatLng coordinates);
+
+typedef void OnFeatureTappedCallback(
+    dynamic id, Point<double> point, LatLng coordinates);
+
 typedef void OnMapLongClickCallback(Point<double> point, LatLng coordinates);
 
 typedef void OnAttributionClickCallback();
@@ -86,8 +90,10 @@ class MapboxMapController extends ChangeNotifier {
       }
     });
 
-    _mapboxGlPlatform.onFeatureTappedPlatform.add((featureId) {
-      onFeatureTapped(featureId);
+    _mapboxGlPlatform.onFeatureTappedPlatform.add((payload) {
+      for (final fun in List<OnFeatureTappedCallback>.from(onFeatureTapped)) {
+        fun(payload["id"], payload["point"], payload["latLng"]);
+      }
     });
 
     _mapboxGlPlatform.onCameraMoveStartedPlatform.add((_) {
@@ -181,8 +187,7 @@ class MapboxMapController extends ChangeNotifier {
   final ArgumentCallbacks<Fill> onFillTapped = ArgumentCallbacks<Fill>();
 
   /// Callbacks to receive tap events for features (geojson layer) placed on this map.
-  final ArgumentCallbacks<dynamic> onFeatureTapped =
-      ArgumentCallbacks<dynamic>();
+  final onFeatureTapped = <OnFeatureTappedCallback>[];
 
   /// Callbacks to receive tap events for info windows on symbols
   final ArgumentCallbacks<Symbol> onInfoWindowTapped =

--- a/mapbox_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
+++ b/mapbox_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
@@ -24,7 +24,7 @@ abstract class MapboxGlPlatform {
 
   final onFillTappedPlatform = ArgumentCallbacks<String>();
 
-  final onFeatureTappedPlatform = ArgumentCallbacks<dynamic>();
+  final onFeatureTappedPlatform = ArgumentCallbacks<Map<String, dynamic>>();
 
   final onCameraMoveStartedPlatform = ArgumentCallbacks<void>();
 

--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -36,10 +36,16 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
         }
         break;
       case 'feature#onTap':
-        final featureId = call.arguments['featureId'];
-        if (featureId != null) {
-          onFeatureTappedPlatform(featureId);
-        }
+        final id = call.arguments['id'];
+        final double x = call.arguments['x'];
+        final double y = call.arguments['y'];
+        final double lng = call.arguments['lng'];
+        final double lat = call.arguments['lat'];
+        onFeatureTappedPlatform({
+          'id': id,
+          'point': Point<double>(x, y),
+          'latLng': LatLng(lat, lng)
+        });
         break;
       case 'camera#onMoveStarted':
         onCameraMoveStartedPlatform(null);

--- a/mapbox_gl_web/lib/src/mapbox_map_controller.dart
+++ b/mapbox_gl_web/lib/src/mapbox_map_controller.dart
@@ -457,13 +457,15 @@ class MapboxMapController extends MapboxGlPlatform
   void _onMapClick(Event e) {
     final features = _map.queryRenderedFeatures(
         [e.point.x, e.point.y], {"layers": _featureLayerIdentifiers.toList()});
+    final payload = {
+      'point': Point<double>(e.point.x.toDouble(), e.point.y.toDouble()),
+      'latLng': LatLng(e.lngLat.lat.toDouble(), e.lngLat.lng.toDouble()),
+      if (features.isNotEmpty) "id": features.first.id,
+    };
     if (features.isNotEmpty) {
-      onFeatureTappedPlatform(features.first.id);
+      onFeatureTappedPlatform(payload);
     } else {
-      onMapClickPlatform({
-        'point': Point<double>(e.point.x.toDouble(), e.point.y.toDouble()),
-        'latLng': LatLng(e.lngLat.lat.toDouble(), e.lngLat.lng.toDouble()),
-      });
+      onMapClickPlatform(payload);
     }
   }
 


### PR DESCRIPTION
Currently on feature tap swallows all map clicks that land on a feature. By also passing all the information to on featureTap that a user can still make the choice to treat a onFeatureTap as a normal click in his code.

In addition this is very helpful if the coordinates are needed, even if a feature has been tapped. 

Note that this breaks the api of onFeatureTapped and users will have to add the new args to the function. This will be caught by the compiler tho and should be trivial to fix.

fixes #792