### PR TITLE
fixed android crash on style switch

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -90,8 +90,6 @@ jobs:
       with:
         java-version: '12.x'
     - uses: subosito/flutter-action@v1
-      with:
-        channel: beta
     - run: flutter config --enable-web
     - run: flutter pub get
     - name: Build web

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -325,7 +325,7 @@ final class MapboxMapController
     public void onStyleLoaded(@NonNull Style style) {
       MapboxMapController.this.style = style;
 
-      // only add managers once to avoid issue with getLayerId for after style switch
+      // only add managers once to avoid issues with getLayerId after a style switch
       if(symbolManager == null && circleManager == null && lineManager == null && fillManager == null)
       {
         final List<String> orderReversed = new ArrayList<String>(annotationOrder);

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -324,26 +324,30 @@ final class MapboxMapController
     @Override
     public void onStyleLoaded(@NonNull Style style) {
       MapboxMapController.this.style = style;
-      final List<String> orderReversed = new ArrayList<String>(annotationOrder);
-      Collections.reverse(orderReversed);
-      String belowLayer = null;
 
-      for(String annotationType : orderReversed) {
-        switch (annotationType) {
-          case "AnnotationType.fill":
-            belowLayer = enableFillManager(style, belowLayer);
-            break;
-          case "AnnotationType.line":
-            belowLayer = enableLineManager(style, belowLayer);
-            break;
-          case "AnnotationType.circle":
-            belowLayer = enableCircleManager(style, belowLayer);
-            break;
-          case "AnnotationType.symbol":
-            belowLayer = enableSymbolManager(style, belowLayer);
-            break;
-          default:
-            throw new IllegalArgumentException("Unknown annotation type: " + annotationType + ", must be either 'fill', 'line', 'circle' or 'symbol'");
+      // only add managers once to avoid issue with getLayerId for after style switch
+      if(symbolManager == null && circleManager == null && lineManager == null && fillManager == null)
+      {
+        final List<String> orderReversed = new ArrayList<String>(annotationOrder);
+        Collections.reverse(orderReversed);
+        String belowLayer = null;
+        for(String annotationType : orderReversed) {
+          switch (annotationType) {
+            case "AnnotationType.fill":
+              belowLayer = enableFillManager(style, belowLayer);
+              break;
+            case "AnnotationType.line":
+              belowLayer = enableLineManager(style, belowLayer);
+              break;
+            case "AnnotationType.circle":
+              belowLayer = enableCircleManager(style, belowLayer);
+              break;
+            case "AnnotationType.symbol":
+              belowLayer = enableSymbolManager(style, belowLayer);
+              break;
+            default:
+              throw new IllegalArgumentException("Unknown annotation type: " + annotationType + ", must be either 'fill', 'line', 'circle' or 'symbol'");
+          }
         }
       }
 


### PR DESCRIPTION
Calling `getLayerId` on a AnnotationManager after the style is has been created on no longer exists _can_ cause an app crash. This is much more likely if myLocationEnabled is set to true.
Fixes https://github.com/flutter-mapbox-gl/maps/issues/809#