### PR TITLE
HOTFIX Add option to not use annotations - android performance 

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 class MapboxMapBuilder implements MapboxMapOptionsSink {
   public final String TAG = getClass().getSimpleName();
   private final MapboxMapOptions options = new MapboxMapOptions()
-    .textureMode(true)
     .attributionEnabled(true);
   private boolean trackCameraPosition = false;
   private boolean myLocationEnabled = false;

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -558,6 +558,11 @@ final class MapboxMapController
 
   @Override
   public void onMethodCall(MethodCall call, MethodChannel.Result result) {
+    String annotationManagerNotCreatedErrorCode = "NO ANNOTATION MANAGER";
+    String annotationManagerNotCreatedErrorMessage = "To use %ss please add it to the annotation list";
+
+
+
     switch (call.method) {
       case "map#waitForMap":
         if (mapboxMap != null) {
@@ -756,6 +761,10 @@ final class MapboxMapController
         break;
       }
       case "symbols#addAll": {
+        if(symbolManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "symbol"), null);
+          return;
+        }
         List<String> newSymbolIds = new ArrayList<String>();
         final List<Object> options = call.argument("options");
         List<SymbolOptions> symbolOptionsList = new ArrayList<SymbolOptions>();
@@ -780,6 +789,10 @@ final class MapboxMapController
         break;
       }
       case "symbols#removeAll": {
+        if(symbolManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "symbol"), null);
+          return;
+        }
         final ArrayList<String> symbolIds = call.argument("ids");
         SymbolController symbolController;
 
@@ -797,6 +810,10 @@ final class MapboxMapController
         break;
       }
       case "symbol#update": {
+        if(symbolManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "symbol"), null);
+          return;
+        }
         final String symbolId = call.argument("symbol");
         final SymbolController symbol = symbol(symbolId);
         Convert.interpretSymbolOptions(call.argument("options"), symbol);
@@ -805,6 +822,10 @@ final class MapboxMapController
         break;
       }
       case "symbol#getGeometry": {
+        if(symbolManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "symbol"), null);
+          return;
+        }
         final String symbolId = call.argument("symbol");
         final SymbolController symbol = symbol(symbolId);
         final LatLng symbolLatLng = symbol.getGeometry();
@@ -814,30 +835,50 @@ final class MapboxMapController
         result.success(hashMapLatLng);
       }
       case "symbolManager#iconAllowOverlap": {
+        if(symbolManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "symbol"), null);
+          return;
+        }
         final Boolean value = call.argument("iconAllowOverlap");
         symbolManager.setIconAllowOverlap(value);
         result.success(null);
         break;
       }
       case "symbolManager#iconIgnorePlacement": {
+        if(symbolManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "symbol"), null);
+          return;
+        }
         final Boolean value = call.argument("iconIgnorePlacement");
         symbolManager.setIconIgnorePlacement(value);
         result.success(null);
         break;
       }
       case "symbolManager#textAllowOverlap": {
+        if(symbolManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "symbol"), null);
+          return;
+        }
         final Boolean value = call.argument("textAllowOverlap");
         symbolManager.setTextAllowOverlap(value);
         result.success(null);
         break;
       }
       case "symbolManager#textIgnorePlacement": {
+        if(symbolManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "symbol"), null);
+          return;
+        }
         final Boolean iconAllowOverlap = call.argument("textIgnorePlacement");
         symbolManager.setTextIgnorePlacement(iconAllowOverlap);
         result.success(null);
         break;
       }
       case "line#add": {
+        if(lineManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "line"), null);
+          return;
+        }
         final LineBuilder lineBuilder = newLineBuilder();
         Convert.interpretLineOptions(call.argument("options"), lineBuilder);
         final Line line = lineBuilder.build();
@@ -847,12 +888,20 @@ final class MapboxMapController
         break;
       }
       case "line#remove": {
+        if(lineManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "line"), null);
+          return;
+        }
         final String lineId = call.argument("line");
         removeLine(lineId);
         result.success(null);
         break;
       }
       case "line#addAll": {
+        if(lineManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "line"), null);
+          return;
+        }
         List<String> newIds = new ArrayList<String>();
         final List<Object> options = call.argument("options");
         List<LineOptions> optionList = new ArrayList<LineOptions>();
@@ -877,6 +926,10 @@ final class MapboxMapController
         break;
       }
       case "line#removeAll": {
+        if(lineManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "line"), null);
+          return;
+        }
         final ArrayList<String> ids = call.argument("ids");
         LineController lineController;
 
@@ -894,6 +947,10 @@ final class MapboxMapController
         break;
       }
       case "line#update": {
+        if(lineManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "line"), null);
+          return;
+        }
         final String lineId = call.argument("line");
         final LineController line = line(lineId);
         Convert.interpretLineOptions(call.argument("options"), line);
@@ -902,6 +959,10 @@ final class MapboxMapController
         break;
       }
       case "line#getGeometry": {
+        if(lineManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "line"), null);
+          return;
+        }
         final String lineId = call.argument("line");
         final LineController line = line(lineId);
         final List<LatLng> lineLatLngs = line.getGeometry();
@@ -916,6 +977,10 @@ final class MapboxMapController
         break;
       }
       case "circle#add": {
+        if(circleManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "circle"), null);
+          return;
+        }
         final CircleBuilder circleBuilder = newCircleBuilder();
         Convert.interpretCircleOptions(call.argument("options"), circleBuilder);
         final Circle circle = circleBuilder.build();
@@ -925,6 +990,10 @@ final class MapboxMapController
         break;
       }
       case "circle#addAll": {
+        if(circleManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "circle"), null);
+          return;
+        }
         List<String> newIds = new ArrayList<String>();
         final List<Object> options = call.argument("options");
         List<CircleOptions> optionList = new ArrayList<CircleOptions>();
@@ -949,6 +1018,10 @@ final class MapboxMapController
         break;
       }
       case "circle#removeAll": {
+        if(circleManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "circle"), null);
+          return;
+        }
         final ArrayList<String> ids = call.argument("ids");
         CircleController circleController;
 
@@ -966,12 +1039,20 @@ final class MapboxMapController
         break;
       }
       case "circle#remove": {
+        if(circleManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "circle"), null);
+          return;
+        }
         final String circleId = call.argument("circle");
         removeCircle(circleId);
         result.success(null);
         break;
       }
       case "circle#update": {
+        if(circleManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "circle"), null);
+          return;
+        }
         Log.e(TAG, "update circle");
         final String circleId = call.argument("circle");
         final CircleController circle = circle(circleId);
@@ -981,6 +1062,10 @@ final class MapboxMapController
         break;
       }
       case "circle#getGeometry": {
+        if(circleManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "circle"), null);
+          return;
+        }
         final String circleId = call.argument("circle");
         final CircleController circle = circle(circleId);
         final LatLng circleLatLng = circle.getGeometry();
@@ -991,6 +1076,10 @@ final class MapboxMapController
         break;
       }
       case "fill#add": {
+        if(fillManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "fill"), null);
+          return;
+        }
         final FillBuilder fillBuilder = newFillBuilder();
         Convert.interpretFillOptions(call.argument("options"), fillBuilder);
         final Fill fill = fillBuilder.build();
@@ -1001,6 +1090,10 @@ final class MapboxMapController
       }
 
       case "fill#addAll": {
+        if(fillManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "fill"), null);
+          return;
+        }
         List<String> newIds = new ArrayList<String>();
         final List<Object> options = call.argument("options");
         List<FillOptions> optionList = new ArrayList<FillOptions>();
@@ -1025,6 +1118,10 @@ final class MapboxMapController
         break;
       }
       case "fill#removeAll": {
+        if(fillManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "fill"), null);
+          return;
+        }
         final ArrayList<String> ids = call.argument("ids");
         FillController fillController;
 
@@ -1042,12 +1139,20 @@ final class MapboxMapController
         break;
       }
       case "fill#remove": {
+        if(fillManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "fill"), null);
+          return;
+        }
         final String fillId = call.argument("fill");
         removeFill(fillId);
         result.success(null);
         break;
       }
       case "fill#update": {
+        if(fillManager == null){
+          result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "fill"), null);
+          return;
+        }
         final String fillId = call.argument("fill");
         final FillController fill = fill(fillId);
         Convert.interpretFillOptions(call.argument("options"), fill);

--- a/example/lib/layer.dart
+++ b/example/lib/layer.dart
@@ -26,15 +26,18 @@ class LayerState extends State {
 
   @override
   Widget build(BuildContext context) {
-    return MapboxMap(
-      accessToken: MapsDemo.ACCESS_TOKEN,
-      onMapCreated: _onMapCreated,
-      onMapClick: (point, latLong) =>
-          print(point.toString() + latLong.toString()),
-      onStyleLoadedCallback: _onStyleLoadedCallback,
-      initialCameraPosition: CameraPosition(
-        target: center,
-        zoom: 11.0,
+    return Container(
+      child: MapboxMap(
+        accessToken: MapsDemo.ACCESS_TOKEN,
+        onMapCreated: _onMapCreated,
+        onMapClick: (point, latLong) =>
+            print(point.toString() + latLong.toString()),
+        onStyleLoadedCallback: _onStyleLoadedCallback,
+        initialCameraPosition: CameraPosition(
+          target: center,
+          zoom: 11.0,
+        ),
+        annotationOrder: const [],
       ),
     );
   }

--- a/example/lib/map_ui.dart
+++ b/example/lib/map_ui.dart
@@ -40,9 +40,10 @@ class MapUiBodyState extends State<MapUiBody> {
   );
 
   MapboxMapController? mapController;
-  CameraPosition? _position = _kInitialPosition;
+  CameraPosition _position = _kInitialPosition;
   bool _isMoving = false;
   bool _compassEnabled = true;
+  bool _mapExpanded = true;
   CameraTargetBounds _cameraTargetBounds = CameraTargetBounds.unbounded;
   MinMaxZoomPreference _minMaxZoomPreference = MinMaxZoomPreference.unbounded;
   int _styleStringIndex = 0;
@@ -80,7 +81,8 @@ class MapUiBodyState extends State<MapUiBody> {
   }
 
   void _extractMapInfo() {
-    _position = mapController!.cameraPosition;
+    final position = mapController!.cameraPosition;
+    if (position != null) _position = position;
     _isMoving = mapController!.isCameraMoving;
   }
 
@@ -119,6 +121,17 @@ class MapUiBodyState extends State<MapUiBody> {
           } else {
             _featureQueryFilter = null;
           }
+        });
+      },
+    );
+  }
+
+  Widget _mapSizeToggler() {
+    return TextButton(
+      child: Text('${_mapExpanded ? 'shrink' : 'expand'} map'),
+      onPressed: () {
+        setState(() {
+          _mapExpanded = !_mapExpanded;
         });
       },
     );
@@ -353,51 +366,42 @@ class MapUiBodyState extends State<MapUiBody> {
     );
 
     final List<Widget> columnChildren = <Widget>[
-      Padding(
-        padding: const EdgeInsets.all(10.0),
-        child: Center(
-          child: SizedBox(
-            width: 300.0,
-            height: 200.0,
-            child: mapboxMap,
-          ),
+      Center(
+        child: SizedBox(
+          width: _mapExpanded ? null : 300.0,
+          height: 200.0,
+          child: mapboxMap,
         ),
       ),
     ];
 
     if (mapController != null) {
-      columnChildren.add(
-        Expanded(
-          child: ListView(
-            children: <Widget>[
-              Text('camera bearing: ${_position!.bearing}'),
-              Text(
-                  'camera target: ${_position!.target.latitude.toStringAsFixed(4)},'
-                  '${_position!.target.longitude.toStringAsFixed(4)}'),
-              Text('camera zoom: ${_position!.zoom}'),
-              Text('camera tilt: ${_position!.tilt}'),
-              Text(_isMoving ? '(Camera moving)' : '(Camera idle)'),
-              _queryFilterToggler(),
-              _compassToggler(),
-              _myLocationTrackingModeCycler(),
-              _latLngBoundsToggler(),
-              _setStyleToSatellite(),
-              _zoomBoundsToggler(),
-              _rotateToggler(),
-              _scrollToggler(),
-              _tiltToggler(),
-              _zoomToggler(),
-              _myLocationToggler(),
-              _telemetryToggler(),
-              _visibleRegionGetter(),
-            ],
-          ),
-        ),
+      columnChildren.addAll(
+        <Widget>[
+          Text('camera bearing: ${_position.bearing}'),
+          Text('camera target: ${_position.target.latitude.toStringAsFixed(4)},'
+              '${_position.target.longitude.toStringAsFixed(4)}'),
+          Text('camera zoom: ${_position.zoom}'),
+          Text('camera tilt: ${_position.tilt}'),
+          Text(_isMoving ? '(Camera moving)' : '(Camera idle)'),
+          _mapSizeToggler(),
+          _queryFilterToggler(),
+          _compassToggler(),
+          _myLocationTrackingModeCycler(),
+          _latLngBoundsToggler(),
+          _setStyleToSatellite(),
+          _zoomBoundsToggler(),
+          _rotateToggler(),
+          _scrollToggler(),
+          _tiltToggler(),
+          _zoomToggler(),
+          _myLocationToggler(),
+          _telemetryToggler(),
+          _visibleRegionGetter(),
+        ],
       );
     }
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
+    return ListView(
       children: columnChildren,
     );
   }

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -53,7 +53,7 @@ class MapboxMap extends StatefulWidget {
       AnnotationType.line,
       AnnotationType.circle,
     ],
-  })  : assert(annotationOrder.length == 4),
+  })  : assert(annotationOrder.length <= 4),
         assert(annotationConsumeTapEvents.length > 0),
         super(key: key);
 


### PR DESCRIPTION
Android performance has been much worse than ios - even on good hardware. #632 #733 #525 

The root cause for this are the annotation managers. It is listening to all map gestures - checking for drag events - causing a massive slow down even if no annotations are added. _Why this causes such a massive slowdown is unknown._

This PR gives the option to pass an empty annotation order `annotationOrder: const []`. If this is done the performance on android should be perfect. However if one does so, using the annotations is no longer possible. 

But with the support of geojson layers, on can still have custom dynamic maps, as long as drag is not needed. 

I will fully fix this in the future by implementing the annotation managers in dart #779

I also disabled textureMode - this should give a big boost in performance in android in general as it moves the processing out of the ui thread.