### PR TITLE
Respect native scale when adding symbols on iOS

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -760,7 +760,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             guard let bytes = arguments["bytes"] as? FlutterStandardTypedData else { return }
             guard let sdf = arguments["sdf"] as? Bool else { return }
             guard let data = bytes.data as? Data else { return }
-            guard let image = UIImage(data: data) else { return }
+            guard let image = UIImage(data: data, scale: UIScreen.main.scale) else { return }
             if sdf {
                 mapView.style?.setImage(image.withRenderingMode(.alwaysTemplate), forName: name)
             } else {


### PR DESCRIPTION
When adding symbols, the native scaling is ignored. (our app displays embedded images as well as custom images downloaded by the app). This causes the images to be displayed with different size.

Below is how it looks using the 0.14.0 version:
![image](https://user-images.githubusercontent.com/6745789/147255867-056cac90-71d1-4d58-8ca4-3e6ba23f2334.png)

And here is the result with the proposed change:
![image](https://user-images.githubusercontent.com/6745789/147256277-0d033909-7417-4c6c-be13-40b2bf6b81ae.png)


Purple icon is loaded from assets, but the orange one is dynamic.