### PR TITLE
updateSymbolsOption, updateSymbols: example, android, ios

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -819,6 +819,39 @@ final class MapboxMapController
         result.success(null);
         break;
       }
+      case "symbols#updateAllOption": {
+        final List<String> updateSymbolIds = call.argument("symbols");
+        final Object options = call.argument("options");
+
+        if (options != null) {
+          List<Symbol> listSymbols = new ArrayList<>();
+          for (String symbolId : updateSymbolIds) {
+            SymbolController symbol = symbol(symbolId);
+            Convert.interpretSymbolOptions(options, symbol);
+            listSymbols.add(symbol.getSymbol());
+          }
+          symbolManager.update(listSymbols);
+        }
+
+        result.success(null);
+        break;
+      }
+      case "symbols#updateAll": {
+        final List<String> updateSymbolIds = call.argument("symbols");
+        final List<Object> options = call.argument("options");
+
+        int i = 0;
+        List<Symbol> listSymbols = new ArrayList<>();
+        for (String symbolId : updateSymbolIds) {
+            SymbolController symbol = symbol(symbolId);
+            Convert.interpretSymbolOptions(options.get(i++), symbol);
+            listSymbols.add(symbol.getSymbol());
+        }
+        symbolManager.update(listSymbols);
+
+        result.success(null);
+        break;
+      }
       case "symbol#getGeometry": {
         if(symbolManager == null){
           result.error(annotationManagerNotCreatedErrorCode, String.format(annotationManagerNotCreatedErrorCode, "symbol"), null);

--- a/example/android/.settings/org.eclipse.buildship.core.prefs
+++ b/example/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,2 +1,13 @@
+arguments=
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(7.1.1))
 connection.project.dir=
 eclipse.preferences.version=1
+gradle.user.home=
+java.home=/Applications/Android Studio.app/Contents/jre/Contents/Home
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
     ndkVersion "20.1.5948944"
     
     lintOptions {

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
-        android:name="io.flutter.app.FlutterApplication"
         android:label="mapbox_gl_example"
         android:icon="@mipmap/ic_launcher">
 

--- a/example/lib/place_symbol.dart
+++ b/example/lib/place_symbol.dart
@@ -40,6 +40,7 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
   int _symbolCount = 0;
   Symbol? _selectedSymbol;
   bool _iconAllowOverlap = false;
+  bool _toggleAllIcons = false;
 
   void _onMapCreated(MapboxMapController controller) {
     this.controller = controller;
@@ -146,6 +147,24 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
         _symbolCount += symbolOptionsList.length;
       });
     }
+  }
+
+  Future<void> _updateSymbolsOption() async {
+    List<Symbol> symbols = controller!.symbols.toList();
+    SymbolOptions option =
+        SymbolOptions(iconImage: _toggleAllIcons ? 'airport-15' : 'bus');
+    _toggleAllIcons = !_toggleAllIcons;
+    controller!.updateSymbolsOption(symbols, option);
+  }
+
+  Future<void> _updateSymbols() async {
+    List<Symbol> symbols = controller!.symbols.toList();
+    List<SymbolOptions> options = List.generate(
+        symbols.length,
+        (index) =>
+            SymbolOptions(iconImage: _toggleAllIcons ? 'airport-15' : 'bus'));
+    _toggleAllIcons = !_toggleAllIcons;
+    controller!.updateSymbols(symbols, options);
   }
 
   void _remove() {
@@ -354,7 +373,13 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
                           child: const Text('add (custom font)'),
                           onPressed: () =>
                               (_symbolCount == 12) ? null : _add("customFont"),
-                        )
+                        ),
+                        TextButton(
+                          child: const Text('updateSymbolsOption'),
+                          onPressed: () => (_symbolCount == 12)
+                              ? _updateSymbolsOption()
+                              : null,
+                        ),
                       ],
                     ),
                     Column(
@@ -408,6 +433,11 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
                           child: const Text('get current LatLng'),
                           onPressed:
                               (_selectedSymbol == null) ? null : _getLatLng,
+                        ),
+                        TextButton(
+                          child: const Text('updateSymbols'),
+                          onPressed: () =>
+                              (_symbolCount == 12) ? _updateSymbols() : null,
                         ),
                       ],
                     ),

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -361,6 +361,44 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 }
             }
             result(nil)
+        case "symbols#updateAllOption":
+            guard let symbolAnnotationController = symbolAnnotationController else { return }
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            guard let symbolIds = arguments["symbols"] as? [String] else { return }
+
+            var updateSymbols: [MGLSymbolStyleAnnotation] = [];
+            var symbols = symbolAnnotationController.styleAnnotations()
+            for id in symbolIds {
+                var symbol = symbols.first(where: { $0.identifier == id}) as! MGLSymbolStyleAnnotation
+                Convert.interpretSymbolOptions(options: arguments["options"], delegate: symbol)
+                if let options = arguments["options"] as? [String: Any],
+                    let iconImage = options["iconImage"] as? String {
+                    addIconImageToMap(iconImageName: iconImage)
+                }
+                updateSymbols.append(symbol)
+            }
+            symbolAnnotationController.updateStyleAnnotations(updateSymbols)
+            result(nil)
+        case "symbols#updateAll":
+            guard let symbolAnnotationController = symbolAnnotationController else { return }
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            guard let symbolIds = arguments["symbols"] as? [String] else { return }
+            guard let options = arguments["options"] as? [[String: Any]] else {return}
+
+            var updateSymbols: [MGLSymbolStyleAnnotation] = [];
+            var symbols = symbolAnnotationController.styleAnnotations()
+            var i = 0;
+            for id in symbolIds {
+                var symbol = symbols.first(where: { $0.identifier == id}) as! MGLSymbolStyleAnnotation
+                Convert.interpretSymbolOptions(options: options[i], delegate: symbol)
+                if let iconImage = options[i]["iconImage"] as? String {
+                    addIconImageToMap(iconImageName: iconImage)
+                }
+                updateSymbols.append(symbol)
+                i += 1
+            }
+            symbolAnnotationController.updateStyleAnnotations(updateSymbols)
+            result(nil)
         case "symbols#removeAll":
             guard let symbolAnnotationController = symbolAnnotationController else { return }
             guard let arguments = methodCall.arguments as? [String: Any] else { return }

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -366,13 +366,15 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
             guard let symbolIds = arguments["symbols"] as? [String] else { return }
 
-            var updateSymbols: [MGLSymbolStyleAnnotation] = [];
+            var updateSymbols: [MGLSymbolStyleAnnotation] = []
             var symbols = symbolAnnotationController.styleAnnotations()
             for id in symbolIds {
-                var symbol = symbols.first(where: { $0.identifier == id}) as! MGLSymbolStyleAnnotation
+                var symbol = symbols
+                    .first(where: { $0.identifier == id }) as! MGLSymbolStyleAnnotation
                 Convert.interpretSymbolOptions(options: arguments["options"], delegate: symbol)
                 if let options = arguments["options"] as? [String: Any],
-                    let iconImage = options["iconImage"] as? String {
+                   let iconImage = options["iconImage"] as? String
+                {
                     addIconImageToMap(iconImageName: iconImage)
                 }
                 updateSymbols.append(symbol)
@@ -383,13 +385,14 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             guard let symbolAnnotationController = symbolAnnotationController else { return }
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
             guard let symbolIds = arguments["symbols"] as? [String] else { return }
-            guard let options = arguments["options"] as? [[String: Any]] else {return}
+            guard let options = arguments["options"] as? [[String: Any]] else { return }
 
-            var updateSymbols: [MGLSymbolStyleAnnotation] = [];
+            var updateSymbols: [MGLSymbolStyleAnnotation] = []
             var symbols = symbolAnnotationController.styleAnnotations()
-            var i = 0;
+            var i = 0
             for id in symbolIds {
-                var symbol = symbols.first(where: { $0.identifier == id}) as! MGLSymbolStyleAnnotation
+                var symbol = symbols
+                    .first(where: { $0.identifier == id }) as! MGLSymbolStyleAnnotation
                 Convert.interpretSymbolOptions(options: options[i], delegate: symbol)
                 if let iconImage = options[i]["iconImage"] as? String {
                     addIconImageToMap(iconImageName: iconImage)

--- a/ios/mapbox_gl.podspec
+++ b/ios/mapbox_gl.podspec
@@ -16,7 +16,7 @@ A new Flutter plugin.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'MapboxAnnotationExtension', '~> 0.0.1-beta.1'
-  s.dependency 'Mapbox-iOS-SDK', '~> 6.4.0'
+  s.dependency 'Mapbox-iOS-SDK', '~> 6.3.0'
   s.swift_version = '4.2'
   s.ios.deployment_target = '9.0'
 end

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -480,6 +480,43 @@ class MapboxMapController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Updates the [symbols] with the given [change]. The symbol must
+  /// be a current member of the [symbols] set.
+  ///
+  /// Change listeners are notified once the symbols have been updated on the
+  /// platform side.
+  ///
+  /// The returned [Future] completes once listeners have been notified.
+  Future<void> updateSymbolsOption(
+      List<Symbol> symbols, SymbolOptions change) async {
+    await _mapboxGlPlatform.updateSymbolsOption(symbols, change);
+    symbols = symbols.map((symbol) {
+      symbol.options = symbol.options.copyWith(change);
+      return symbol;
+    }).toList();
+    notifyListeners();
+  }
+
+  /// Updates the [symbols] with the given [changes]. The symbol must
+  /// be a current member of the [symbols] set.
+  ///
+  /// Change listeners are notified once the symbols have been updated on the
+  /// platform side.
+  ///
+  /// The returned [Future] completes once listeners have been notified.
+  Future<void> updateSymbols(
+      List<Symbol> symbols, List<SymbolOptions> changes) async {
+    assert(symbols.length == changes.length);
+    await _mapboxGlPlatform.updateSymbols(symbols, changes);
+
+    int i = 0;
+    symbols = symbols.map((symbol) {
+      symbol.options = symbol.options.copyWith(changes[i++]);
+      return symbol;
+    }).toList();
+    notifyListeners();
+  }
+
   /// Retrieves the current position of the symbol.
   /// This may be different from the value of `symbol.options.geometry` if the symbol is draggable.
   /// In that case this method provides the symbol's actual position, and `symbol.options.geometry` the last programmatically set position.

--- a/mapbox_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
+++ b/mapbox_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
@@ -111,6 +111,16 @@ abstract class MapboxGlPlatform {
     throw UnimplementedError('updateSymbol() has not been implemented.');
   }
 
+  Future<void> updateSymbolsOption(
+      List<Symbol> symbols, SymbolOptions change) async {
+    throw UnimplementedError('updateSymbolsOption() has not been implemented.');
+  }
+
+  Future<void> updateSymbols(
+      List<Symbol> symbols, List<SymbolOptions> changes) async {
+    throw UnimplementedError('updateSymbols() has not been implemented.');
+  }
+
   Future<void> removeSymbols(Iterable<String> symbolsIds) async {
     throw UnimplementedError('removeSymbol() has not been implemented.');
   }

--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -261,6 +261,24 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   }
 
   @override
+  Future<void> updateSymbolsOption(
+      List<Symbol> symbols, SymbolOptions change) async {
+    await _channel.invokeMethod('symbols#updateAllOption', <String, dynamic>{
+      'symbols': symbols.map((s) => s.id).toList(),
+      'options': change.toJson(),
+    });
+  }
+
+  @override
+  Future<void> updateSymbols(
+      List<Symbol> symbols, List<SymbolOptions> changes) async {
+    await _channel.invokeMethod('symbols#updateAll', <String, dynamic>{
+      'symbols': symbols.map((s) => s.id).toList(),
+      'options': changes.map((c) => c.toJson()).toList()
+    });
+  }
+
+  @override
   Future<LatLng> getSymbolLatLng(Symbol symbol) async {
     Map mapLatLng =
         await _channel.invokeMethod('symbol#getGeometry', <String, dynamic>{

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   collection:
     dependency: transitive
     description:
@@ -74,6 +74,13 @@ packages:
       relative: true
     source: path
     version: "0.14.0"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -113,7 +120,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   xml:
     dependency: transitive
     description:
@@ -122,5 +129,5 @@ packages:
     source: hosted
     version: "5.1.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=2.0.0"


### PR DESCRIPTION
I added two functions for updating an array of symbols on the map:

- updateSymbolsOption(List<Symbol> symbols, SymbolOptions change) 
updating a list of symbol by a single `SymbolOptions` object.
- updateSymbols(List<Symbol> symbols, List<SymbolOptions> changes)
updating a list of symbol with a `SymbolOptions` object for each one.

## Motivation
Consider, we have dozens of moving objects on the map. Updating the properties for every symbol is a time consuming job if we are utilizing the current `updateSymbol` for each one. Also, removing and then adding all symbols at once, is not a nice job which would cause a flicker effect to be seen on them map.
Hence, to improve the updating time, we can provide the SDK with list of symbols and their options to update them all at once.

## Example
I added the functions to `example/lib/place_symbol.dart`

## Problems
- I had to set `compileSdkVersion=31` to run the example on Android.
- I had to set `'Mapbox-iOS-SDK', '~> 6.3.0'` to run the example on IOS.