### PR TITLE
remove unnecessary print of style height and width

### DIFF
--- a/mapbox_gl_web/lib/src/mapbox_map_controller.dart
+++ b/mapbox_gl_web/lib/src/mapbox_map_controller.dart
@@ -40,7 +40,9 @@ class MapboxMapController extends MapboxGlPlatform
     // ignore: undefined_prefixed_name
     ui.platformViewRegistry.registerViewFactory(
         'plugins.flutter.io/mapbox_gl_$identifier', (int viewId) {
-      _mapElement = DivElement();
+      _mapElement = DivElement()
+        ..style.width = '100%'
+        ..style.height = '100%';
       callback(viewId);
       return _mapElement;
     });


### PR DESCRIPTION
This fix should remove the console logs for flutter web related to the height and width of the map not being 100%. 