### PR TITLE
Fix type issues in query rendered features in rect

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -864,11 +864,13 @@ class MapboxMapController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Query rendered features at a point in screen cooridnates
   Future<List> queryRenderedFeatures(
       Point<double> point, List<String> layerIds, List<Object>? filter) async {
     return _mapboxGlPlatform.queryRenderedFeatures(point, layerIds, filter);
   }
 
+  /// Query rendered features in a Rect in screen coordinates
   Future<List> queryRenderedFeaturesInRect(
       Rect rect, List<String> layerIds, String? filter) async {
     return _mapboxGlPlatform.queryRenderedFeaturesInRect(

--- a/mapbox_gl_web/lib/src/mapbox_map_controller.dart
+++ b/mapbox_gl_web/lib/src/mapbox_map_controller.dart
@@ -326,7 +326,7 @@ class MapboxMapController extends MapboxGlPlatform
         ], options)
         .map((feature) => {
               'type': 'Feature',
-              'id': feature.id as int?,
+              'id': feature.id,
               'geometry': {
                 'type': feature.geometry.type,
                 'coordinates': feature.geometry.coordinates,


### PR DESCRIPTION
If `queryRenderedFeaturesInRect` was called on a source that uses promote id to set strings as ids, the function would throw.