### PR TITLE
Fix for MissingPluginException when using downloadOfflineRegion

### DIFF
--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -101,7 +101,7 @@ Future<OfflineRegion> downloadOfflineRegion(
       'downloadOfflineRegion_${DateTime.now().microsecondsSinceEpoch}';
 
   final result =
-      _globalChannel.invokeMethod('downloadOfflineRegion', <String, dynamic>{
+      await _globalChannel.invokeMethod('downloadOfflineRegion', <String, dynamic>{
     'accessToken': accessToken,
     'channelName': channelName,
     'definition': definition.toMap(),
@@ -153,5 +153,5 @@ Future<OfflineRegion> downloadOfflineRegion(
     });
   }
 
-  return OfflineRegion.fromMap(json.decode(await result));
+  return OfflineRegion.fromMap(json.decode(result));
 }

--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -100,8 +100,8 @@ Future<OfflineRegion> downloadOfflineRegion(
   String channelName =
       'downloadOfflineRegion_${DateTime.now().microsecondsSinceEpoch}';
 
-  final result =
-      await _globalChannel.invokeMethod('downloadOfflineRegion', <String, dynamic>{
+  final result = await _globalChannel
+      .invokeMethod('downloadOfflineRegion', <String, dynamic>{
     'accessToken': accessToken,
     'channelName': channelName,
     'definition': definition.toMap(),


### PR DESCRIPTION
* Fix for issue [#840](https://github.com/flutter-mapbox-gl/maps/issues/840). Added "await" when creating a new EventChannel so it doesn't throw MissingPluginException when trying to use said channel to call "receiveBroadcastStream()".