### PR TITLE
Fix urls parsing

### DIFF
--- a/ios/Classes/SourcePropertyConverter.swift
+++ b/ios/Classes/SourcePropertyConverter.swift
@@ -46,7 +46,7 @@ class SourcePropertyConverter {
     class func buildVectorTileSource(identifier: String,
                                      properties: [String: Any]) -> MGLVectorTileSource?
     {
-        if let url = properties["url"] as? String, let url = URL(string: url) {
+        if let rawUrl = properties["url"] as? String, let url = URL(string: rawUrl) {
             return MGLVectorTileSource(identifier: identifier, configurationURL: url)
         }
         if let tiles = properties["tiles"] as? [String] {
@@ -62,7 +62,7 @@ class SourcePropertyConverter {
     class func buildRasterDemSource(identifier: String,
                                     properties: [String: Any]) -> MGLRasterDEMSource?
     {
-        if let url = properties["url"] as? String, let url = URL(string: url) {
+        if let rawUrl = properties["url"] as? String, let url = URL(string: rawUrl) {
             return MGLRasterDEMSource(identifier: identifier, configurationURL: url)
         }
         if let tiles = properties["tiles"] as? [String] {
@@ -123,7 +123,7 @@ class SourcePropertyConverter {
     }
 
     class func buildImageSource(identifier: String, properties: [String: Any]) -> MGLImageSource? {
-        if let url = properties["url"] as? String, let url = URL(string: url),
+        if let rawUrl = properties["url"] as? String, let url = URL(string: rawUrl),
            let coordinates = properties["coordinates"] as? [[Double]]
         {
             return MGLImageSource(


### PR DESCRIPTION
This PR fixes the error:
```
flutter/.pub-cache/hosted/pub.dartlang.org/mapbox_gl-0.15.0/ios/Classes/SourcePropertyConverter.swift:132:22: error: cannot convert value of type 'String' to expected argument type 'URL'
                    url: url
```

that was introduced in https://github.com/flutter-mapbox-gl/maps/commit/a484bc4fee3178add990d76996df1a1338a75fb6