### PR TITLE
Change repository URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We welcome contributions to this repository. Please follow these steps if you're
 
 - Please familiarize yourself with the process of running the example app and adding Mapbox access tokens as described in the Readme. 
 
-- Ensure that existing [pull requests](https://github.com/tobrun/flutter-mapbox-gl/pulls) and [issues](https://github.com/tobrun/flutter-mapbox-gl/issues) don’t already cover your contributions or questions.
+- Ensure that existing [pull requests](https://github.com/flutter-mapbox-gl/maps/pulls) and [issues](https://github.com/flutter-mapbox-gl/maps/issues) don’t already cover your contributions or questions.
 
 - Create a new branch that will contain your contributed code. Along with your contribution you should also adapt the example app to showcase any new features or APIs you have developed. This also makes testing your contribution much easier. In an ideal case, you also make your contribution cross platform but this isn't a true requirement. Eventually create a pull request once you're done making changes.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Please note that this project is community driven and is not an official Mapbox product.** 
 > 
-> We welcome [feedback](https://github.com/tobrun/flutter-mapbox-gl/issues) and contributions.
+> We welcome [feedback](https://github.com/flutter-mapbox-gl/maps/issues) and contributions.
 
 This Flutter plugin allows to show embedded interactive and customizable vector maps inside a Flutter widget. For the Android and iOS integration, we use [mapbox-gl-native](https://github.com/mapbox/mapbox-gl-native). For web, we rely on [mapbox-gl-js](https://github.com/mapbox/mapbox-gl-js). This project only supports a subset of the API exposed by these libraries. 
 
@@ -162,4 +162,4 @@ xml ...
 
 ## Contributing
 
-We welcome contributions to this repository! If you're interested in helping build this Mapbox-Flutter integration, please read [the contribution guide](https://github.com/tobrun/flutter-mapbox-gl/blob/master/CONTRIBUTING.md) to learn how to get started.
+We welcome contributions to this repository! If you're interested in helping build this Mapbox-Flutter integration, please read [the contribution guide](https://github.com/flutter-mapbox-gl/maps/blob/master/CONTRIBUTING.md) to learn how to get started.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,7 +29,7 @@ Update library version in `mapbox_gl_web/pubspec.yaml` in `mapbox_gl_platform_in
 Replace:
 mapbox_gl_platform_interface:
   git:
-    url: https://github.com/tobrun/flutter-mapbox-gl.git
+    url: https://github.com/flutter-mapbox-gl/maps.git
     path: mapbox_gl_platform_interface
 
 With:

--- a/android/src/main/java/com/mapbox/mapboxgl/MapBoxUtils.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapBoxUtils.java
@@ -32,7 +32,7 @@ abstract class MapBoxUtils {
           TAG,
           "Failed to find an Access Token in the Application meta-data. Maps may not load"
               + " correctly. Please refer to the installation guide at"
-              + " https://github.com/tobrun/flutter-mapbox-gl#mapbox-access-token for"
+              + " https://github.com/flutter-mapbox-gl/maps#mapbox-access-token for"
               + " troubleshooting advice."
               + e.getMessage());
     }

--- a/mapbox_gl_platform_interface/README.md
+++ b/mapbox_gl_platform_interface/README.md
@@ -1,1 +1,1 @@
-Contains the web platform implementation for the [Flutter Mapbox GL plugin](https://github.com/tobrun/flutter-mapbox-gl).
+Contains the web platform implementation for the [Flutter Mapbox GL plugin](https://github.com/flutter-mapbox-gl/maps).

--- a/mapbox_gl_platform_interface/pubspec.yaml
+++ b/mapbox_gl_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mapbox_gl_platform_interface
 description: A common platform interface for the mapbox_gl plugin.
 version: 0.15.0
-homepage: https://github.com/tobrun/flutter-mapbox-gl
+homepage: https://github.com/flutter-mapbox-gl/maps
 
 dependencies:
   flutter:

--- a/mapbox_gl_web/README.md
+++ b/mapbox_gl_web/README.md
@@ -1,1 +1,1 @@
-Contains the web interfaces for the [Flutter Mapbox GL plugin](https://github.com/tobrun/flutter-mapbox-gl).
+Contains the web interfaces for the [Flutter Mapbox GL plugin](https://github.com/flutter-mapbox-gl/maps).

--- a/mapbox_gl_web/pubspec.yaml
+++ b/mapbox_gl_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mapbox_gl_web
 description: Web platform implementation of mapbox_gl
 version: 0.15.0
-homepage: https://github.com/tobrun/flutter-mapbox-gl
+homepage: https://github.com/flutter-mapbox-gl/maps
 
 flutter:
   plugin:
@@ -18,7 +18,7 @@ dependencies:
   meta: ^1.1.7
   mapbox_gl_platform_interface:
     git:
-      url: https://github.com/tobrun/flutter-mapbox-gl.git
+      url: https://github.com/flutter-mapbox-gl/maps.git
       path: mapbox_gl_platform_interface
   mapbox_gl_dart: ^0.2.1
   image: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,18 @@
 name: mapbox_gl
 description: A Flutter plugin for integrating Mapbox Maps inside a Flutter application on Android, iOS and web platfroms.
 version: 0.15.0
-homepage: https://github.com/tobrun/flutter-mapbox-gl
+homepage: https://github.com/flutter-mapbox-gl/maps
 
 dependencies:
   flutter:
     sdk: flutter
   mapbox_gl_platform_interface:
     git:
-      url: https://github.com/tobrun/flutter-mapbox-gl.git
+      url: https://github.com/flutter-mapbox-gl/maps.git
       path: mapbox_gl_platform_interface
   mapbox_gl_web:
     git:
-      url: https://github.com/tobrun/flutter-mapbox-gl.git
+      url: https://github.com/flutter-mapbox-gl/maps.git
       path: mapbox_gl_web
   collection: ^1.15.0
 


### PR DESCRIPTION
This changes the URL from Tobrun's repository to the organization's repository.

It doesn't include changelogs at this time. Should I change them as well? The new links do work if I do.