### PR TITLE
fixed issue with map disposal on web

### DIFF
--- a/mapbox_gl_platform_interface/lib/src/callbacks.dart
+++ b/mapbox_gl_platform_interface/lib/src/callbacks.dart
@@ -46,6 +46,11 @@ class ArgumentCallbacks<T> {
     _callbacks.remove(callback);
   }
 
+  /// Removes all callbacks
+  void clear() {
+    _callbacks.clear();
+  }
+
   /// Whether this collection is empty.
   bool get isEmpty => _callbacks.isEmpty;
 

--- a/mapbox_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
+++ b/mapbox_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
@@ -136,5 +136,23 @@ abstract class MapboxGlPlatform {
 
   Future<void> addSource(String sourceId, SourceProperties properties);
 
-  void dispose() {}
+  @mustCallSuper
+  void dispose() {
+    // clear all callbacks to avoid cyclic refs
+    onInfoWindowTappedPlatform.clear();
+    onFeatureTappedPlatform.clear();
+    onFeatureDraggedPlatform.clear();
+    onCameraMoveStartedPlatform.clear();
+    onCameraMovePlatform.clear();
+    onCameraIdlePlatform.clear();
+    onMapStyleLoadedPlatform.clear();
+
+    onMapClickPlatform.clear();
+    onMapLongClickPlatform.clear();
+    onAttributionClickPlatform.clear();
+    onCameraTrackingChangedPlatform.clear();
+    onCameraTrackingDismissedPlatform.clear();
+    onMapIdlePlatform.clear();
+    onUserLocationUpdatedPlatform.clear();
+  }
 }

--- a/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
+++ b/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
@@ -36,6 +36,12 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
         viewType: 'plugins.flutter.io/mapbox_gl_${this.hashCode}');
   }
 
+  @override
+  void dispose() {
+    super.dispose();
+    _map.remove();
+  }
+
   void _registerViewFactory(Function(int) callback, int identifier) {
     // ignore: undefined_prefixed_name
     ui.platformViewRegistry.registerViewFactory(


### PR DESCRIPTION
Sometimes after a map has been disposed by the framework, one of two things would happen:

- a callback (e.g. cameraMoved) was called after the controller has been disposed - causing an error as it tried to notifyListeners after a disposal.

- the map would try to redraw after the canvas had been disposed - this would fully crash the web app.

To fix this i removed all callback from within the controller on disposal (this should also allow the GC to collect it)  and the web platform plugin now also properly releases all resources avoiding redraws.
