### PR TITLE
Update "Setting up" section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,20 @@ This project is available on [pub.dev](https://pub.dev/packages/mapbox_gl), foll
 
 ### Private Mapbox access token
 
-This project does require a Mapbox access token to download the underlying Android/iOS SDKs. The secret access token must have the *Download: read* scope for
-[Android](https://docs.mapbox.com/android/maps/guides/install/) and/or 
+On mobile, a secret access token with the *Downloads: Read* scope is **required** for the underlying Mapbox SDKs to be downloaded.
+Information on setting it up is available in the Mapbox documentation:
+[Android](https://docs.mapbox.com/android/maps/guides/install/),
 [iOS](https://docs.mapbox.com/ios/maps/guides/install/).
 
-If this configuration is not present, an error like the following appears during 
-the build process:
+If the properly configured token is not present,
+the build process fails with one the following errors *(for Android/iOS respectively)*:
 
-#### Android
 ```
 * What went wrong:
 A problem occurred evaluating project ':mapbox_gl'.
 > SDK Registry token is null. See README.md for more information.
 ```
 
-#### iOS
 ```
 [!] Error installing Mapbox-iOS-SDK
 curl: (22) The requested URL returned error: 401 Unauthorized

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This Flutter plugin allows to show embedded interactive and customizable vector 
 
 ![screenshot.png](screenshot.png)
 
-## How to use
+## Setting up
 
 This package is available on [pub.dev](https://pub.dev/packages/mapbox_gl).
 

--- a/README.md
+++ b/README.md
@@ -65,20 +65,20 @@ The example app uses the following technique:
 The access token is passed via the command line arguments when either building
 
 ```
-flutter build <platform> --dart-define=ACCESS_TOKEN=YOUR_TOKEN_HERE
+flutter build <platform> --dart-define ACCESS_TOKEN=YOUR_TOKEN_HERE
 ```
 
 or running the application
 
 ```
-flutter run --dart-define=ACCESS_TOKEN=YOUR_TOKEN_HERE
+flutter run --dart-define ACCESS_TOKEN=YOUR_TOKEN_HERE
 ```
 
-Then it's retrieved at runtime:
+Then it's retrieved in Dart:
 ```
 MapBoxMap(
   ...
-  accessToken: String.fromEnvironment("ACCESS_TOKEN"),
+  accessToken: const String.fromEnvironment("ACCESS_TOKEN"),
   ...
 )
 ```

--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ MapBoxMap(
 )
 ```
 
+### Web
+
+Include the JavaScript and CSS files in the `<head>` of your `index.html` file:
+
+```
+<script src='https://api.mapbox.com/mapbox-gl-js/v2.7.0/mapbox-gl.js'></script>
+<link href='https://api.mapbox.com/mapbox-gl-js/v2.7.0/mapbox-gl.css' rel='stylesheet' />
+```
+
+*Note: Look for latest version in [Mapbox GL JS documentation](https://docs.mapbox.com/mapbox-gl-js/guides/).*
+
 ## Supported API
 
 | Feature | Android | iOS | Web |

--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@ This Flutter plugin allows to show embedded interactive and customizable vector 
 
 ![screenshot.png](screenshot.png)
 
-
 ## How to use
 
-This project is available on [pub.dev](https://pub.dev/packages/mapbox_gl), follow the [instructions](https://flutter.dev/docs/development/packages-and-plugins/using-packages#adding-a-package-dependency-to-an-app) to add a package into your flutter application. 
+This package is available on [pub.dev](https://pub.dev/packages/mapbox_gl).
+
+Get it by running the following command:
+
+```
+flutter pub add mapbox_gl
+```
 
 ### Private Mapbox access token
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ flutter run --dart-define ACCESS_TOKEN=YOUR_TOKEN_HERE
 
 Then it's retrieved in Dart:
 ```
-MapBoxMap(
+MapboxMap(
   ...
   accessToken: const String.fromEnvironment("ACCESS_TOKEN"),
   ...

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Get it by running the following command:
 flutter pub add mapbox_gl
 ```
 
-### Private Mapbox access token
+### Mobile
 
-On mobile, a secret access token with the *Downloads: Read* scope is **required** for the underlying Mapbox SDKs to be downloaded.
+#### Secret Mapbox access token
+
+A secret access token with the `Downloads: Read` scope is required for the underlying Mapbox SDKs to be downloaded.
 Information on setting it up is available in the Mapbox documentation:
 [Android](https://docs.mapbox.com/android/maps/guides/install/),
 [iOS](https://docs.mapbox.com/ios/maps/guides/install/).
@@ -39,31 +41,6 @@ A problem occurred evaluating project ':mapbox_gl'.
 curl: (22) The requested URL returned error: 401 Unauthorized
 ```
 
-### Public Mapbox access token
-
-A public access token must be provided to a MapboxMap widget for retrieving styles and resources.
-While you can hardcode it directly into source files,
-it's good practise to retrieve access tokens from some external source
-(e.g. a config file or an environment variable).
-The example app uses the following technique:
-
-The access token is passed via the command line arguments when either building or running the application:
-
-```
-flutter build <platform> --dart-define=ACCESS_TOKEN=YOUR_TOKEN_HERE
-/
-flutter run --dart-define=ACCESS_TOKEN=YOUR_TOKEN_HERE
-```
-
-Then it's retrieved at runtime:
-```
-MapBoxMap(
-   ...
-   accessToken: String.fromEnvironment("ACCESS_TOKEN"),
-   ...
-)
-```
-
 ### Web
 
 Include the JavaScript and CSS files in the `<head>` of your `index.html` file:
@@ -74,6 +51,37 @@ Include the JavaScript and CSS files in the `<head>` of your `index.html` file:
 ```
 
 *Note: Look for latest version in [Mapbox GL JS documentation](https://docs.mapbox.com/mapbox-gl-js/guides/).*
+
+### All platforms
+
+#### Public Mapbox access token
+
+A public access token must be provided to a MapboxMap widget for retrieving styles and resources.
+While you can hardcode it directly into source files,
+it's good practise to retrieve access tokens from some external source
+(e.g. a config file or an environment variable).
+The example app uses the following technique:
+
+The access token is passed via the command line arguments when either building
+
+```
+flutter build <platform> --dart-define=ACCESS_TOKEN=YOUR_TOKEN_HERE
+```
+
+or running the application
+
+```
+flutter run --dart-define=ACCESS_TOKEN=YOUR_TOKEN_HERE
+```
+
+Then it's retrieved at runtime:
+```
+MapBoxMap(
+  ...
+  accessToken: String.fromEnvironment("ACCESS_TOKEN"),
+  ...
+)
+```
 
 ## Supported API
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,27 @@ curl: (22) The requested URL returned error: 401 Unauthorized
 
 ### Public Mapbox access token
 
-Next to a private access token you will need to provide an public access token
-to retrieve the style and underlying resources. This can be done with running your application with an additional define statement:
+A public access token must be provided to a MapboxMap widget for retrieving styles and resources.
+While you can hardcode it directly into source files,
+it's good practise to retrieve access tokens from some external source
+(e.g. a config file or an environment variable).
+The example app uses the following technique:
+
+The access token is passed via the command line arguments when either building or running the application:
 
 ```
-flutter run -d {device_id} --dart-define=ACCESS_TOKEN=ADD_YOUR_TOKEN_HERE`
+flutter build <platform> --dart-define=ACCESS_TOKEN=YOUR_TOKEN_HERE
+/
+flutter run --dart-define=ACCESS_TOKEN=YOUR_TOKEN_HERE
+```
+
+Then it's retrieved at runtime:
+```
+MapBoxMap(
+   ...
+   accessToken: String.fromEnvironment("ACCESS_TOKEN"),
+   ...
+)
 ```
 
 ## Supported API


### PR DESCRIPTION
Information in the "How to use" section of README is somewhat confusing and messy.
It is not clear to users what they need to do to start using the package.
This is indicated by #906 and #878.

The goal is to clear it up.
