### PR TITLE
Fix symbol loading for web and ios

### DIFF
--- a/ios/Classes/Extensions.swift
+++ b/ios/Classes/Extensions.swift
@@ -81,17 +81,20 @@ extension UIImage {
         // Add the trailing slash in path if missing.
         let path = imagePath.hasSuffix("/") ? imagePath : "\(imagePath)/"
         // Build scale dependant image path.
-        let scale = UIScreen.main.scale
+        var scale = UIScreen.main.scale
         var absolutePath = "\(path)\(scale)x/\(imageName)"
         // Check if the image exists, if not try a an unscaled path.
         if Bundle.main.path(forResource: absolutePath, ofType: nil) == nil {
             absolutePath = "\(path)\(imageName)"
+        } else {
+            // found asset with higher resoultion increase scale even futher
+            scale *= scale
         }
         // Load image if it exists.
         if let path = Bundle.main.path(forResource: absolutePath, ofType: nil) {
             let imageUrl = URL(fileURLWithPath: path)
             if let imageData: Data = try? Data(contentsOf: imageUrl),
-               let image = UIImage(data: imageData, scale: UIScreen.main.scale)
+               let image = UIImage(data: imageData, scale: scale)
             {
                 return image
             }

--- a/ios/Classes/Extensions.swift
+++ b/ios/Classes/Extensions.swift
@@ -87,7 +87,7 @@ extension UIImage {
         if Bundle.main.path(forResource: absolutePath, ofType: nil) == nil {
             absolutePath = "\(path)\(imageName)"
         } else {
-            // found asset with higher resoultion increase scale even futher
+            // found asset with higher resolution - increase scale even further to compensate
             scale *= scale
         }
         // Load image if it exists.

--- a/mapbox_gl_web/lib/mapbox_gl_web.dart
+++ b/mapbox_gl_web/lib/mapbox_gl_web.dart
@@ -9,6 +9,7 @@ import 'dart:js';
 import 'dart:math';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
+import 'package:flutter/services.dart';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';

--- a/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
+++ b/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
@@ -83,12 +83,19 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
       _map.on('move', _onCameraMove);
       _map.on('moveend', _onCameraIdle);
       _map.on('resize', _onMapResize);
+      _map.on('styleimagemissing', _loadFromAssets);
       if (_dragEnabled) {
         _map.on('mouseup', _onMouseUp);
         _map.on('mousemove', _onMouseMove);
       }
     }
     Convert.interpretMapboxMapOptions(_creationParams['options'], this);
+  }
+
+  void _loadFromAssets(Event event) async {
+    final imagePath = event.id;
+    final ByteData bytes = await rootBundle.load(imagePath);
+    await addImage(imagePath, bytes.buffer.asUint8List());
   }
 
   _onMouseDown(Event e) {


### PR DESCRIPTION
Currently users have to add symbols manually on ios and web. With this PR missing symbols are loaded automatically -> fixes #923  

So a user can just directly give the path to the asset via `SymbolOptions(iconImage: "path/to/asset")`

