### PR TITLE
Improve performance of removing multiple annotations

### DIFF
--- a/lib/src/annotation_manager.dart
+++ b/lib/src/annotation_manager.dart
@@ -103,6 +103,14 @@ abstract class AnnotationManager<T extends Annotation> {
     await _setAll();
   }
 
+  /// Removes multiple annotations from the map
+  Future<void> removeAll(Iterable<T> annotations) async {
+    for (var a in annotations) {
+      _idToAnnotation.remove(a.id);
+    }
+    await _setAll();
+  }
+
   /// Remove a single annotation form the map
   Future<void> remove(T annotation) async {
     _idToAnnotation.remove(annotation.id);

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -610,9 +610,7 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes once listeners have been notified.
   Future<void> removeSymbols(Iterable<Symbol> symbols) async {
-    for (var symbol in symbols) {
-      await symbolManager!.remove(symbol);
-    }
+    await symbolManager!.removeAll(symbols);
     notifyListeners();
   }
 
@@ -702,10 +700,7 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes once listeners have been notified.
   Future<void> removeLines(Iterable<Line> lines) async {
-    for (var line in lines) {
-      await lineManager!.remove(line);
-    }
-
+    await lineManager!.removeAll(lines);
     notifyListeners();
   }
 
@@ -799,9 +794,7 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes once listeners have been notified.
   Future<void> removeCircles(Iterable<Circle> circles) async {
-    for (var circle in circles) {
-      await circleManager!.remove(circle);
-    }
+    await circleManager!.removeAll(circles);
     notifyListeners();
   }
 
@@ -900,10 +893,7 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes once listeners have been notified.
   Future<void> removeFills(Iterable<Fill> fills) async {
-    for (var fill in fills) {
-      await fillManager!.remove(fill);
-    }
-
+    await fillManager!.removeAll(fills);
     notifyListeners();
   }
 


### PR DESCRIPTION
Currently, the functions that remove multiple annotations (e.g., `removeLines`, `removeFills`) remove them one at a time from the annotation manager. I added a function in the annotation manager to remove multiple annotations, which will hopefully improve the performance of these functions.