### PR TITLE
fix location puck getting hidden

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -220,6 +220,9 @@ final class MapboxMapController
 
   @Override
   public void setStyleString(String styleString) {
+    // clear old layer id from the location Component
+    clearLocationComponentLayer();
+
     // Check if json, url, absolute path or asset path:
     if (styleString == null || styleString.isEmpty()) {
       Log.e(TAG, "setStyleString - string empty or null");
@@ -246,9 +249,7 @@ final class MapboxMapController
         public void onStyleLoaded(@NonNull Style style) {
           MapboxMapController.this.style = style;
 
-          if (myLocationEnabled) {
-            enableLocationComponent(style);
-          }
+          updateMyLocationEnabled();
 
           if (null != bounds) {
             mapboxMap.setLatLngBoundsForCameraTarget(bounds);
@@ -266,22 +267,46 @@ final class MapboxMapController
   private void enableLocationComponent(@NonNull Style style) {
     if (hasLocationPermission()) {
       locationEngine = LocationEngineProvider.getBestLocationEngine(context);
-      LocationComponentOptions locationComponentOptions =
-          LocationComponentOptions.builder(context).trackingGesturesManagement(true).build();
       locationComponent = mapboxMap.getLocationComponent();
-      locationComponent.activateLocationComponent(context, style, locationComponentOptions);
+      locationComponent.activateLocationComponent(
+          context, style, buildLocationComponentOptions(style));
       locationComponent.setLocationComponentEnabled(true);
       // locationComponent.setRenderMode(RenderMode.COMPASS); // remove or keep default?
       locationComponent.setLocationEngine(locationEngine);
       locationComponent.setMaxAnimationFps(30);
       updateMyLocationTrackingMode();
-      setMyLocationTrackingMode(this.myLocationTrackingMode);
       updateMyLocationRenderMode();
-      setMyLocationRenderMode(this.myLocationRenderMode);
       locationComponent.addOnCameraTrackingChangedListener(this);
     } else {
       Log.e(TAG, "missing location permissions");
     }
+  }
+
+  private void updateLocationLocationComponentLayer() {
+    if (locationComponent != null && style != null) {
+      locationComponent.applyStyle(buildLocationComponentOptions(style));
+    }
+  }
+
+  private void clearLocationComponentLayer() {
+    if (locationComponent != null) {
+      locationComponent.applyStyle(buildLocationComponentOptions(null));
+    }
+  }
+
+  private LocationComponentOptions buildLocationComponentOptions(Style style) {
+    final LocationComponentOptions.Builder optionsBuilder =
+        LocationComponentOptions.builder(context);
+    optionsBuilder.trackingGesturesManagement(true);
+
+    if (style != null) {
+      final List<Layer> layers = style.getLayers();
+      if (layers.size() > 0) {
+        optionsBuilder.layerAbove(layers.get(layers.size() - 1).getId());
+        Log.i(TAG, layers.get(layers.size() - 1).getId());
+      }
+    }
+    return optionsBuilder.build();
   }
 
   private void onUserLocationUpdate(Location location) {
@@ -798,6 +823,8 @@ final class MapboxMapController
               properties,
               enableInteraction,
               null);
+          updateLocationLocationComponentLayer();
+
           result.success(null);
           break;
         }
@@ -822,6 +849,8 @@ final class MapboxMapController
               properties,
               enableInteraction,
               null);
+          updateLocationLocationComponentLayer();
+
           result.success(null);
           break;
         }
@@ -846,6 +875,8 @@ final class MapboxMapController
               properties,
               enableInteraction,
               null);
+          updateLocationLocationComponentLayer();
+
           result.success(null);
           break;
         }
@@ -870,6 +901,8 @@ final class MapboxMapController
               properties,
               enableInteraction,
               null);
+          updateLocationLocationComponentLayer();
+
           result.success(null);
           break;
         }
@@ -890,6 +923,8 @@ final class MapboxMapController
               belowLayerId,
               properties,
               null);
+          updateLocationLocationComponentLayer();
+
           result.success(null);
           break;
         }
@@ -910,6 +945,8 @@ final class MapboxMapController
               belowLayerId,
               properties,
               null);
+          updateLocationLocationComponentLayer();
+
           result.success(null);
           break;
         }


### PR DESCRIPTION
Currently new layers of any kind hide the location puck under them on android.

With this PR the location locationComponent is updated whenever a new layer is added to move it above the new layer. Fixes #692
