### PR TITLE
Handle missing layers better when removing layer/source

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -528,7 +528,10 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         case "style#removeSource":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
             guard let sourceId = arguments["sourceId"] as? String else { return }
-            guard let source = mapView.style?.source(withIdentifier: sourceId) else { return }
+            guard let source = mapView.style?.source(withIdentifier: sourceId) else {
+                result(nil)
+                return
+            }
             mapView.style?.removeSource(source)
             result(nil)
         case "style#addLayer":
@@ -709,7 +712,10 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         case "style#removeLayer":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
             guard let layerId = arguments["layerId"] as? String else { return }
-            guard let layer = mapView.style?.layer(withIdentifier: layerId) else { return }
+            guard let layer = mapView.style?.layer(withIdentifier: layerId) else {
+                result(nil)
+                return
+            }
             interactiveFeatureLayerIds.remove(layerId)
             mapView.style?.removeLayer(layer)
             result(nil)


### PR DESCRIPTION
Resolve https://github.com/flutter-mapbox-gl/maps/issues/960
Set result to correctly return to dart if layer/source are missing when trying to remove