### PR TITLE
features with non string ids will did not update properly

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -1326,6 +1326,10 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                         if let id = $0.identifier as? String,
                            let featureId = feature.identifier as? String
                         { return id == featureId }
+
+                        if let id = $0.identifier as? NSNumber,
+                           let featureId = feature.identifier as? NSNumber
+                        { return id == featureId }
                         return false
                     })
                 {


### PR DESCRIPTION
if features use non string ids they will not update as expected using setGeoJsonFeature on iOS.