### PR TITLE
Drag event types support added

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -1635,6 +1635,24 @@ final class MapboxMapController
       RectF rectF = new RectF(pointf.x - 10, pointf.y - 10, pointf.x + 10, pointf.y + 10);
       Feature feature = firstFeatureOnLayers(rectF);
       if (feature != null && startDragging(feature, origin)) {
+
+        LatLng current = mapboxMap.getProjection().fromScreenLocation(pointf);
+
+        final Map<String, Object> arguments = new HashMap<>(9);
+        arguments.put("id", draggedFeature.id());
+        arguments.put("x", pointf.x);
+        arguments.put("y", pointf.y);
+
+        arguments.put("originLng", dragOrigin.getLongitude());
+        arguments.put("originLat", dragOrigin.getLatitude());
+        arguments.put("currentLng", current.getLongitude());
+        arguments.put("currentLat", current.getLatitude());
+        arguments.put("eventType", "start");
+        arguments.put("deltaLng", current.getLongitude() - dragPrevious.getLongitude());
+        arguments.put("deltaLat", current.getLatitude() - dragPrevious.getLatitude());
+
+        methodChannel.invokeMethod("feature#onDrag", arguments);
+
         return true;
       }
     }
@@ -1660,6 +1678,7 @@ final class MapboxMapController
       arguments.put("originLat", dragOrigin.getLatitude());
       arguments.put("currentLng", current.getLongitude());
       arguments.put("currentLat", current.getLatitude());
+      arguments.put("eventType", "drag");
       arguments.put("deltaLng", current.getLongitude() - dragPrevious.getLongitude());
       arguments.put("deltaLat", current.getLatitude() - dragPrevious.getLatitude());
 
@@ -1670,7 +1689,25 @@ final class MapboxMapController
     return true;
   }
 
-  void onMoveEnd() {
+  void onMoveEnd(MoveGestureDetector detector) {
+
+    PointF pointf = detector.getFocalPoint();
+    LatLng current = mapboxMap.getProjection().fromScreenLocation(pointf);
+
+    final Map<String, Object> arguments = new HashMap<>(9);
+    arguments.put("id", draggedFeature.id());
+    arguments.put("x", pointf.x);
+    arguments.put("y", pointf.y);
+
+    arguments.put("originLng", dragOrigin.getLongitude());
+    arguments.put("originLat", dragOrigin.getLatitude());
+    arguments.put("currentLng", current.getLongitude());
+    arguments.put("currentLat", current.getLatitude());
+    arguments.put("eventType", "end");
+    arguments.put("deltaLng", current.getLongitude() - dragPrevious.getLongitude());
+    arguments.put("deltaLat", current.getLatitude() - dragPrevious.getLatitude());
+
+    methodChannel.invokeMethod("feature#onDrag", arguments);
     stopDragging();
   }
 
@@ -1708,7 +1745,7 @@ final class MapboxMapController
 
     @Override
     public void onMoveEnd(MoveGestureDetector detector, float velocityX, float velocityY) {
-      MapboxMapController.this.onMoveEnd();
+      MapboxMapController.this.onMoveEnd(detector);
     }
   }
 }

--- a/example/lib/place_fill.dart
+++ b/example/lib/place_fill.dart
@@ -57,6 +57,12 @@ class PlaceFillBodyState extends State<PlaceFillBody> {
   void _onMapCreated(MapboxMapController controller) {
     this.controller = controller;
     controller.onFillTapped.add(_onFillTapped);
+    this.controller!.onFeatureDrag.add(_onFeatureDrag);
+  }
+
+  void _onFeatureDrag(id,
+      {required current, required delta, required origin, required point, required eventType}) {
+    var g = 1;
   }
 
   void _onStyleLoaded() {
@@ -88,10 +94,7 @@ class PlaceFillBodyState extends State<PlaceFillBody> {
 
   void _add() {
     controller!.addFill(
-      FillOptions(
-          geometry: _defaultGeometry,
-          fillColor: "#FF0000",
-          fillOutlineColor: "#FF0000"),
+      FillOptions(geometry: _defaultGeometry, fillColor: "#FF0000", fillOutlineColor: "#FF0000"),
     );
     setState(() {
       _fillCount += 1;
@@ -113,14 +116,9 @@ class PlaceFillBodyState extends State<PlaceFillBody> {
       geometry = _defaultGeometry;
     }
 
-    _updateSelectedFill(FillOptions(
-        geometry: geometry
-            .map((list) => list
-                .map(
-                    // Move to right with 0.1 degree on longitude
-                    (latLng) => LatLng(latLng.latitude, latLng.longitude + 0.1))
-                .toList())
-            .toList()));
+    _updateSelectedFill(FillOptions(geometry: geometry.map((list) => list.map(
+        // Move to right with 0.1 degree on longitude
+        (latLng) => LatLng(latLng.latitude, latLng.longitude + 0.1)).toList()).toList()));
   }
 
   void _changeDraggable() {
@@ -171,8 +169,7 @@ class PlaceFillBodyState extends State<PlaceFillBody> {
   }
 
   Future<void> _changeFillPattern() async {
-    String? current =
-        _selectedFill!.options.fillPattern == null ? "assetImage" : null;
+    String? current = _selectedFill!.options.fillPattern == null ? "assetImage" : null;
     _updateSelectedFill(
       FillOptions(fillPattern: current),
     );
@@ -222,36 +219,27 @@ class PlaceFillBodyState extends State<PlaceFillBody> {
                       children: <Widget>[
                         TextButton(
                           child: const Text('change fill-opacity'),
-                          onPressed: (_selectedFill == null)
-                              ? null
-                              : _changeFillOpacity,
+                          onPressed: (_selectedFill == null) ? null : _changeFillOpacity,
                         ),
                         TextButton(
                           child: const Text('change fill-color'),
-                          onPressed:
-                              (_selectedFill == null) ? null : _changeFillColor,
+                          onPressed: (_selectedFill == null) ? null : _changeFillColor,
                         ),
                         TextButton(
                           child: const Text('change fill-outline-color'),
-                          onPressed: (_selectedFill == null)
-                              ? null
-                              : _changeFillOutlineColor,
+                          onPressed: (_selectedFill == null) ? null : _changeFillOutlineColor,
                         ),
                         TextButton(
                           child: const Text('change fill-pattern'),
-                          onPressed: (_selectedFill == null)
-                              ? null
-                              : _changeFillPattern,
+                          onPressed: (_selectedFill == null) ? null : _changeFillPattern,
                         ),
                         TextButton(
                           child: const Text('change position'),
-                          onPressed:
-                              (_selectedFill == null) ? null : _changePosition,
+                          onPressed: (_selectedFill == null) ? null : _changePosition,
                         ),
                         TextButton(
                           child: const Text('toggle draggable'),
-                          onPressed:
-                              (_selectedFill == null) ? null : _changeDraggable,
+                          onPressed: (_selectedFill == null) ? null : _changeDraggable,
                         ),
                       ],
                     ),

--- a/example/lib/place_fill.dart
+++ b/example/lib/place_fill.dart
@@ -62,7 +62,18 @@ class PlaceFillBodyState extends State<PlaceFillBody> {
 
   void _onFeatureDrag(id,
       {required current, required delta, required origin, required point, required eventType}) {
-    var g = 1;
+    DragEventType type = eventType;
+    switch (type) {
+      case DragEventType.start:
+        // TODO: Handle this case.
+        break;
+      case DragEventType.drag:
+        // TODO: Handle this case.
+        break;
+      case DragEventType.end:
+        // TODO: Handle this case.
+        break;
+    }
   }
 
   void _onStyleLoaded() {

--- a/example/lib/place_fill.dart
+++ b/example/lib/place_fill.dart
@@ -61,7 +61,11 @@ class PlaceFillBodyState extends State<PlaceFillBody> {
   }
 
   void _onFeatureDrag(id,
-      {required current, required delta, required origin, required point, required eventType}) {
+      {required current,
+      required delta,
+      required origin,
+      required point,
+      required eventType}) {
     DragEventType type = eventType;
     switch (type) {
       case DragEventType.start:
@@ -105,7 +109,10 @@ class PlaceFillBodyState extends State<PlaceFillBody> {
 
   void _add() {
     controller!.addFill(
-      FillOptions(geometry: _defaultGeometry, fillColor: "#FF0000", fillOutlineColor: "#FF0000"),
+      FillOptions(
+          geometry: _defaultGeometry,
+          fillColor: "#FF0000",
+          fillOutlineColor: "#FF0000"),
     );
     setState(() {
       _fillCount += 1;
@@ -127,9 +134,14 @@ class PlaceFillBodyState extends State<PlaceFillBody> {
       geometry = _defaultGeometry;
     }
 
-    _updateSelectedFill(FillOptions(geometry: geometry.map((list) => list.map(
-        // Move to right with 0.1 degree on longitude
-        (latLng) => LatLng(latLng.latitude, latLng.longitude + 0.1)).toList()).toList()));
+    _updateSelectedFill(FillOptions(
+        geometry: geometry
+            .map((list) => list
+                .map(
+                    // Move to right with 0.1 degree on longitude
+                    (latLng) => LatLng(latLng.latitude, latLng.longitude + 0.1))
+                .toList())
+            .toList()));
   }
 
   void _changeDraggable() {
@@ -180,7 +192,8 @@ class PlaceFillBodyState extends State<PlaceFillBody> {
   }
 
   Future<void> _changeFillPattern() async {
-    String? current = _selectedFill!.options.fillPattern == null ? "assetImage" : null;
+    String? current =
+        _selectedFill!.options.fillPattern == null ? "assetImage" : null;
     _updateSelectedFill(
       FillOptions(fillPattern: current),
     );
@@ -230,27 +243,36 @@ class PlaceFillBodyState extends State<PlaceFillBody> {
                       children: <Widget>[
                         TextButton(
                           child: const Text('change fill-opacity'),
-                          onPressed: (_selectedFill == null) ? null : _changeFillOpacity,
+                          onPressed: (_selectedFill == null)
+                              ? null
+                              : _changeFillOpacity,
                         ),
                         TextButton(
                           child: const Text('change fill-color'),
-                          onPressed: (_selectedFill == null) ? null : _changeFillColor,
+                          onPressed:
+                              (_selectedFill == null) ? null : _changeFillColor,
                         ),
                         TextButton(
                           child: const Text('change fill-outline-color'),
-                          onPressed: (_selectedFill == null) ? null : _changeFillOutlineColor,
+                          onPressed: (_selectedFill == null)
+                              ? null
+                              : _changeFillOutlineColor,
                         ),
                         TextButton(
                           child: const Text('change fill-pattern'),
-                          onPressed: (_selectedFill == null) ? null : _changeFillPattern,
+                          onPressed: (_selectedFill == null)
+                              ? null
+                              : _changeFillPattern,
                         ),
                         TextButton(
                           child: const Text('change position'),
-                          onPressed: (_selectedFill == null) ? null : _changePosition,
+                          onPressed:
+                              (_selectedFill == null) ? null : _changePosition,
                         ),
                         TextButton(
                           child: const Text('toggle draggable'),
-                          onPressed: (_selectedFill == null) ? null : _changeDraggable,
+                          onPressed:
+                              (_selectedFill == null) ? null : _changeDraggable,
                         ),
                       ],
                     ),

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -876,7 +876,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             originDragCoordinate = coordinate
             previousDragCoordinate = coordinate
             mapView.allowsScrolling = false
-            let eventType = "sart"
+            let eventType = "start"
             invokeFeatureDrag(point, coordinate, eventType)
             for gestureRecognizer in mapView.gestureRecognizers! {
                 if let _ = gestureRecognizer as? UIPanGestureRecognizer {

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -875,7 +875,6 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             dragFeature = feature
             originDragCoordinate = coordinate
             previousDragCoordinate = coordinate
-            print("drag start")
             mapView.allowsScrolling = false
             let eventType = "sart"
             invokeFeatureDrag(point, coordinate, eventType)
@@ -888,7 +887,6 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         }
         if end, dragFeature != nil {
             mapView.allowsScrolling = true
-            print("drag end")
             let eventType = "end"
             invokeFeatureDrag(point, coordinate, eventType)
             dragFeature = nil

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -859,7 +859,39 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                     break
                 }
             }
+            channel?.invokeMethod("feature#onDrag", arguments: [
+                            "id": feature.identifier,
+                            "x": point.x,
+                            "y": point.y,
+                            "originLng": coordinate.longitude,
+                            "originLat": coordinate.latitude,
+                            "currentLng": coordinate.longitude,
+                            "currentLat": coordinate.latitude,
+                            "deltaLng":0,
+                            "eventType":"start",
+                            "deltaLat":0,
+              ])
+
         } else if sender.state == UIGestureRecognizer.State.ended || sender.numberOfTouches != 1 {
+            
+            
+            let prevLat = previousDragCoordinate?.latitude ?? 0;
+            let prevLng = previousDragCoordinate?.longitude ?? 0;
+
+            channel?.invokeMethod("feature#onDrag", arguments: [
+                "id": dragFeature?.identifier,
+                "x": point.x,
+                "y": point.y,
+                "originLng": originDragCoordinate?.longitude,
+                "originLat": originDragCoordinate?.latitude,
+                "currentLng": coordinate.longitude,
+                "currentLat": coordinate.latitude,
+                "deltaLng": coordinate.longitude - prevLng,
+                "eventType":"end",
+                "deltaLat": coordinate.latitude - prevLat,
+            ])
+            
+
             sender.state = UIGestureRecognizer.State.ended
             mapView.allowsScrolling = scrollingEnabled
             dragFeature = nil
@@ -880,6 +912,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 "currentLng": coordinate.longitude,
                 "currentLat": coordinate.latitude,
                 "deltaLng": coordinate.longitude - previous.longitude,
+                "eventType":"drag",
                 "deltaLat": coordinate.latitude - previous.latitude,
             ])
             previousDragCoordinate = coordinate

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -860,23 +860,21 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 }
             }
             channel?.invokeMethod("feature#onDrag", arguments: [
-                            "id": feature.identifier,
-                            "x": point.x,
-                            "y": point.y,
-                            "originLng": coordinate.longitude,
-                            "originLat": coordinate.latitude,
-                            "currentLng": coordinate.longitude,
-                            "currentLat": coordinate.latitude,
-                            "deltaLng":0,
-                            "eventType":"start",
-                            "deltaLat":0,
-              ])
+                "id": feature.identifier,
+                "x": point.x,
+                "y": point.y,
+                "originLng": coordinate.longitude,
+                "originLat": coordinate.latitude,
+                "currentLng": coordinate.longitude,
+                "currentLat": coordinate.latitude,
+                "deltaLng": 0,
+                "eventType": "start",
+                "deltaLat": 0,
+            ])
 
         } else if sender.state == UIGestureRecognizer.State.ended || sender.numberOfTouches != 1 {
-            
-            
-            let prevLat = previousDragCoordinate?.latitude ?? 0;
-            let prevLng = previousDragCoordinate?.longitude ?? 0;
+            let prevLat = previousDragCoordinate?.latitude ?? 0
+            let prevLng = previousDragCoordinate?.longitude ?? 0
 
             channel?.invokeMethod("feature#onDrag", arguments: [
                 "id": dragFeature?.identifier,
@@ -887,10 +885,9 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 "currentLng": coordinate.longitude,
                 "currentLat": coordinate.latitude,
                 "deltaLng": coordinate.longitude - prevLng,
-                "eventType":"end",
+                "eventType": "end",
                 "deltaLat": coordinate.latitude - prevLat,
             ])
-            
 
             sender.state = UIGestureRecognizer.State.ended
             mapView.allowsScrolling = scrollingEnabled
@@ -912,7 +909,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 "currentLng": coordinate.longitude,
                 "currentLat": coordinate.latitude,
                 "deltaLng": coordinate.longitude - previous.longitude,
-                "eventType":"drag",
+                "eventType": "drag",
                 "deltaLat": coordinate.latitude - previous.latitude,
             ])
             previousDragCoordinate = coordinate

--- a/lib/src/annotation_manager.dart
+++ b/lib/src/annotation_manager.dart
@@ -34,8 +34,7 @@ abstract class AnnotationManager<T extends Annotation> {
       : id = getRandomString() {
     for (var i = 0; i < allLayerProperties.length; i++) {
       final layerId = _makeLayerId(i);
-      controller.addGeoJsonSource(layerId, buildFeatureCollection([]),
-          promoteId: "id");
+      controller.addGeoJsonSource(layerId, buildFeatureCollection([]), promoteId: "id");
       controller.addLayer(layerId, layerId, allLayerProperties[i]);
     }
 
@@ -75,16 +74,12 @@ abstract class AnnotationManager<T extends Annotation> {
       }
 
       for (var i = 0; i < featureBuckets.length; i++) {
-        await controller.setGeoJsonSource(
-            _makeLayerId(i),
-            buildFeatureCollection(
-                [for (final l in featureBuckets[i]) l.toGeoJson()]));
+        await controller.setGeoJsonSource(_makeLayerId(i),
+            buildFeatureCollection([for (final l in featureBuckets[i]) l.toGeoJson()]));
       }
     } else {
-      await controller.setGeoJsonSource(
-          _makeLayerId(0),
-          buildFeatureCollection(
-              [for (final l in _idToAnnotation.values) l.toGeoJson()]));
+      await controller.setGeoJsonSource(_makeLayerId(0),
+          buildFeatureCollection([for (final l in _idToAnnotation.values) l.toGeoJson()]));
     }
   }
 
@@ -139,7 +134,8 @@ abstract class AnnotationManager<T extends Annotation> {
       {required Point<double> point,
       required LatLng origin,
       required LatLng current,
-      required LatLng delta}) {
+      required LatLng delta,
+      required DragEventType eventType}) {
     final annotation = byId(id);
     if (annotation != null) {
       annotation.translate(delta);
@@ -150,8 +146,7 @@ abstract class AnnotationManager<T extends Annotation> {
   /// Set an existing anntotation to the map. Use this to do a fast update for a
   /// single annotation
   Future<void> set(T anntotation) async {
-    assert(_idToAnnotation.containsKey(anntotation.id),
-        "you can only set existing annotations");
+    assert(_idToAnnotation.containsKey(anntotation.id), "you can only set existing annotations");
     _idToAnnotation[anntotation.id] = anntotation;
     final oldLayerIndex = _idToLayerIndex[anntotation.id];
     final layerIndex = selectLayer != null ? selectLayer!(anntotation) : 0;
@@ -160,8 +155,7 @@ abstract class AnnotationManager<T extends Annotation> {
       // set all
       await _setAll();
     } else {
-      await controller.setGeoJsonFeature(
-          _makeLayerId(layerIndex), anntotation.toGeoJson());
+      await controller.setGeoJsonFeature(_makeLayerId(layerIndex), anntotation.toGeoJson());
     }
   }
 }
@@ -188,8 +182,8 @@ class LineManager extends AnnotationManager<Line> {
   @override
   List<LayerProperties> get allLayerProperties => [
         _baseProperties,
-        _baseProperties.copyWith(
-            LineLayerProperties(linePattern: [Expressions.get, 'linePattern'])),
+        _baseProperties
+            .copyWith(LineLayerProperties(linePattern: [Expressions.get, 'linePattern'])),
       ];
 }
 

--- a/lib/src/annotation_manager.dart
+++ b/lib/src/annotation_manager.dart
@@ -34,7 +34,8 @@ abstract class AnnotationManager<T extends Annotation> {
       : id = getRandomString() {
     for (var i = 0; i < allLayerProperties.length; i++) {
       final layerId = _makeLayerId(i);
-      controller.addGeoJsonSource(layerId, buildFeatureCollection([]), promoteId: "id");
+      controller.addGeoJsonSource(layerId, buildFeatureCollection([]),
+          promoteId: "id");
       controller.addLayer(layerId, layerId, allLayerProperties[i]);
     }
 
@@ -74,12 +75,16 @@ abstract class AnnotationManager<T extends Annotation> {
       }
 
       for (var i = 0; i < featureBuckets.length; i++) {
-        await controller.setGeoJsonSource(_makeLayerId(i),
-            buildFeatureCollection([for (final l in featureBuckets[i]) l.toGeoJson()]));
+        await controller.setGeoJsonSource(
+            _makeLayerId(i),
+            buildFeatureCollection(
+                [for (final l in featureBuckets[i]) l.toGeoJson()]));
       }
     } else {
-      await controller.setGeoJsonSource(_makeLayerId(0),
-          buildFeatureCollection([for (final l in _idToAnnotation.values) l.toGeoJson()]));
+      await controller.setGeoJsonSource(
+          _makeLayerId(0),
+          buildFeatureCollection(
+              [for (final l in _idToAnnotation.values) l.toGeoJson()]));
     }
   }
 
@@ -146,7 +151,8 @@ abstract class AnnotationManager<T extends Annotation> {
   /// Set an existing anntotation to the map. Use this to do a fast update for a
   /// single annotation
   Future<void> set(T anntotation) async {
-    assert(_idToAnnotation.containsKey(anntotation.id), "you can only set existing annotations");
+    assert(_idToAnnotation.containsKey(anntotation.id),
+        "you can only set existing annotations");
     _idToAnnotation[anntotation.id] = anntotation;
     final oldLayerIndex = _idToLayerIndex[anntotation.id];
     final layerIndex = selectLayer != null ? selectLayer!(anntotation) : 0;
@@ -155,7 +161,8 @@ abstract class AnnotationManager<T extends Annotation> {
       // set all
       await _setAll();
     } else {
-      await controller.setGeoJsonFeature(_makeLayerId(layerIndex), anntotation.toGeoJson());
+      await controller.setGeoJsonFeature(
+          _makeLayerId(layerIndex), anntotation.toGeoJson());
     }
   }
 }
@@ -182,8 +189,8 @@ class LineManager extends AnnotationManager<Line> {
   @override
   List<LayerProperties> get allLayerProperties => [
         _baseProperties,
-        _baseProperties
-            .copyWith(LineLayerProperties(linePattern: [Expressions.get, 'linePattern'])),
+        _baseProperties.copyWith(
+            LineLayerProperties(linePattern: [Expressions.get, 'linePattern'])),
       ];
 }
 

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -6,7 +6,8 @@ part of mapbox_gl;
 
 typedef void OnMapClickCallback(Point<double> point, LatLng coordinates);
 
-typedef void OnFeatureInteractionCallback(dynamic id, Point<double> point, LatLng coordinates);
+typedef void OnFeatureInteractionCallback(
+    dynamic id, Point<double> point, LatLng coordinates);
 
 typedef void OnFeatureDragnCallback(dynamic id,
     {required Point<double> point,
@@ -64,15 +65,16 @@ class MapboxMapController extends ChangeNotifier {
     _cameraPosition = initialCameraPosition;
 
     _mapboxGlPlatform.onFeatureTappedPlatform.add((payload) {
-      for (final fun in List<OnFeatureInteractionCallback>.from(onFeatureTapped)) {
+      for (final fun
+          in List<OnFeatureInteractionCallback>.from(onFeatureTapped)) {
         fun(payload["id"], payload["point"], payload["latLng"]);
       }
     });
 
     _mapboxGlPlatform.onFeatureDraggedPlatform.add((payload) {
       for (final fun in List<OnFeatureDragnCallback>.from(onFeatureDrag)) {
-        final DragEventType enmDragEventType =
-            DragEventType.values.firstWhere((element) => element.name == payload["eventType"]);
+        final DragEventType enmDragEventType = DragEventType.values
+            .firstWhere((element) => element.name == payload["eventType"]);
         fun(payload["id"],
             point: payload["point"],
             origin: payload["origin"],
@@ -109,20 +111,20 @@ class MapboxMapController extends ChangeNotifier {
         final enableInteraction = interactionEnabled.contains(type);
         switch (type) {
           case AnnotationType.fill:
-            fillManager =
-                FillManager(this, onTap: onFillTapped, enableInteraction: enableInteraction);
+            fillManager = FillManager(this,
+                onTap: onFillTapped, enableInteraction: enableInteraction);
             break;
           case AnnotationType.line:
-            lineManager =
-                LineManager(this, onTap: onLineTapped, enableInteraction: enableInteraction);
+            lineManager = LineManager(this,
+                onTap: onLineTapped, enableInteraction: enableInteraction);
             break;
           case AnnotationType.circle:
-            circleManager =
-                CircleManager(this, onTap: onCircleTapped, enableInteraction: enableInteraction);
+            circleManager = CircleManager(this,
+                onTap: onCircleTapped, enableInteraction: enableInteraction);
             break;
           case AnnotationType.symbol:
-            symbolManager =
-                SymbolManager(this, onTap: onSymbolTapped, enableInteraction: enableInteraction);
+            symbolManager = SymbolManager(this,
+                onTap: onSymbolTapped, enableInteraction: enableInteraction);
             break;
           default:
         }
@@ -207,7 +209,8 @@ class MapboxMapController extends ChangeNotifier {
 
   /// Callbacks to receive tap events for info windows on symbols
   @Deprecated("InfoWindow tapped is no longer supported")
-  final ArgumentCallbacks<Symbol> onInfoWindowTapped = ArgumentCallbacks<Symbol>();
+  final ArgumentCallbacks<Symbol> onInfoWindowTapped =
+      ArgumentCallbacks<Symbol>();
 
   /// The current set of symbols on this map.
   ///
@@ -289,7 +292,8 @@ class MapboxMapController extends ChangeNotifier {
   ///
   Future<void> addGeoJsonSource(String sourceId, Map<String, dynamic> geojson,
       {String? promoteId}) async {
-    await _mapboxGlPlatform.addGeoJsonSource(sourceId, geojson, promoteId: promoteId);
+    await _mapboxGlPlatform.addGeoJsonSource(sourceId, geojson,
+        promoteId: promoteId);
   }
 
   /// Sets new geojson data to and existing source
@@ -303,7 +307,8 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes after the change has been made on the
   /// platform side.
-  Future<void> setGeoJsonSource(String sourceId, Map<String, dynamic> geojson) async {
+  Future<void> setGeoJsonSource(
+      String sourceId, Map<String, dynamic> geojson) async {
     await _mapboxGlPlatform.setGeoJsonSource(sourceId, geojson);
   }
 
@@ -318,8 +323,10 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes after the change has been made on the
   /// platform side.
-  Future<void> setGeoJsonFeature(String sourceId, Map<String, dynamic> geojsonFeature) async {
-    await _mapboxGlPlatform.setFeatureForGeoJsonSource(sourceId, geojsonFeature);
+  Future<void> setGeoJsonFeature(
+      String sourceId, Map<String, dynamic> geojsonFeature) async {
+    await _mapboxGlPlatform.setFeatureForGeoJsonSource(
+        sourceId, geojsonFeature);
   }
 
   /// Add a symbol layer to the map with the given properties
@@ -333,7 +340,8 @@ class MapboxMapController extends ChangeNotifier {
   /// If [enableInteraction] is set the layer is considered for touch or drag
   /// events. [sourceLayer] is used to selected a specific source layer from
   /// Vector source
-  Future<void> addSymbolLayer(String sourceId, String layerId, SymbolLayerProperties properties,
+  Future<void> addSymbolLayer(
+      String sourceId, String layerId, SymbolLayerProperties properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -362,7 +370,8 @@ class MapboxMapController extends ChangeNotifier {
   /// If [enableInteraction] is set the layer is considered for touch or drag
   /// events. [sourceLayer] is used to selected a specific source layer from
   /// Vector source
-  Future<void> addLineLayer(String sourceId, String layerId, LineLayerProperties properties,
+  Future<void> addLineLayer(
+      String sourceId, String layerId, LineLayerProperties properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -391,7 +400,8 @@ class MapboxMapController extends ChangeNotifier {
   /// If [enableInteraction] is set the layer is considered for touch or drag
   /// events. [sourceLayer] is used to selected a specific source layer from
   /// Vector source
-  Future<void> addFillLayer(String sourceId, String layerId, FillLayerProperties properties,
+  Future<void> addFillLayer(
+      String sourceId, String layerId, FillLayerProperties properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -420,7 +430,8 @@ class MapboxMapController extends ChangeNotifier {
   /// If [enableInteraction] is set the layer is considered for touch or drag
   /// events. [sourceLayer] is used to selected a specific source layer from
   /// Vector source
-  Future<void> addCircleLayer(String sourceId, String layerId, CircleLayerProperties properties,
+  Future<void> addCircleLayer(
+      String sourceId, String layerId, CircleLayerProperties properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -448,8 +459,12 @@ class MapboxMapController extends ChangeNotifier {
   /// Setting [belowLayerId] adds the new layer below the given id.
   /// [sourceLayer] is used to selected a specific source layer from
   /// Raster source
-  Future<void> addRasterLayer(String sourceId, String layerId, RasterLayerProperties properties,
-      {String? belowLayerId, String? sourceLayer, double? minzoom, double? maxzoom}) async {
+  Future<void> addRasterLayer(
+      String sourceId, String layerId, RasterLayerProperties properties,
+      {String? belowLayerId,
+      String? sourceLayer,
+      double? minzoom,
+      double? maxzoom}) async {
     await _mapboxGlPlatform.addRasterLayer(
       sourceId,
       layerId,
@@ -473,7 +488,10 @@ class MapboxMapController extends ChangeNotifier {
   /// Raster source
   Future<void> addHillshadeLayer(
       String sourceId, String layerId, HillshadeLayerProperties properties,
-      {String? belowLayerId, String? sourceLayer, double? minzoom, double? maxzoom}) async {
+      {String? belowLayerId,
+      String? sourceLayer,
+      double? minzoom,
+      double? maxzoom}) async {
     await _mapboxGlPlatform.addHillshadeLayer(
       sourceId,
       layerId,
@@ -489,8 +507,10 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes after the change has been made on the
   /// platform side.
-  Future<void> updateMyLocationTrackingMode(MyLocationTrackingMode myLocationTrackingMode) async {
-    return _mapboxGlPlatform.updateMyLocationTrackingMode(myLocationTrackingMode);
+  Future<void> updateMyLocationTrackingMode(
+      MyLocationTrackingMode myLocationTrackingMode) async {
+    return _mapboxGlPlatform
+        .updateMyLocationTrackingMode(myLocationTrackingMode);
   }
 
   /// Updates the language of the map labels to match the device's language.
@@ -512,7 +532,8 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes after the change has been made on the
   /// platform side.
-  Future<void> updateContentInsets(EdgeInsets insets, [bool animated = false]) async {
+  Future<void> updateContentInsets(EdgeInsets insets,
+      [bool animated = false]) async {
     return _mapboxGlPlatform.updateContentInsets(insets, animated);
   }
 
@@ -565,10 +586,12 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes with the added symbol once listeners have
   /// been notified.
-  Future<List<Symbol>> addSymbols(List<SymbolOptions> options, [List<Map>? data]) async {
+  Future<List<Symbol>> addSymbols(List<SymbolOptions> options,
+      [List<Map>? data]) async {
     final symbols = [
       for (var i = 0; i < options.length; i++)
-        Symbol(getRandomString(), SymbolOptions.defaultOptions.copyWith(options[i]), data?[i])
+        Symbol(getRandomString(),
+            SymbolOptions.defaultOptions.copyWith(options[i]), data?[i])
     ];
     await symbolManager!.addAll(symbols);
 
@@ -584,7 +607,8 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes once listeners have been notified.
   Future<void> updateSymbol(Symbol symbol, SymbolOptions changes) async {
-    await symbolManager!.set(symbol..options = symbol.options.copyWith(changes));
+    await symbolManager!
+        .set(symbol..options = symbol.options.copyWith(changes));
 
     notifyListeners();
   }
@@ -653,10 +677,12 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes with the added line once listeners have
   /// been notified.
-  Future<List<Line>> addLines(List<LineOptions> options, [List<Map>? data]) async {
+  Future<List<Line>> addLines(List<LineOptions> options,
+      [List<Map>? data]) async {
     final lines = [
       for (var i = 0; i < options.length; i++)
-        Line(getRandomString(), LineOptions.defaultOptions.copyWith(options[i]), data?[i])
+        Line(getRandomString(), LineOptions.defaultOptions.copyWith(options[i]),
+            data?[i])
     ];
     await lineManager!.addAll(lines);
 
@@ -727,7 +753,8 @@ class MapboxMapController extends ChangeNotifier {
   /// The returned [Future] completes with the added circle once listeners have
   /// been notified.
   Future<Circle> addCircle(CircleOptions options, [Map? data]) async {
-    final CircleOptions effectiveOptions = CircleOptions.defaultOptions.copyWith(options);
+    final CircleOptions effectiveOptions =
+        CircleOptions.defaultOptions.copyWith(options);
     final circle = Circle(getRandomString(), effectiveOptions, data);
     await circleManager!.add(circle);
     notifyListeners();
@@ -742,10 +769,12 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes with the added circle once listeners have
   /// been notified.
-  Future<List<Circle>> addCircles(List<CircleOptions> options, [List<Map>? data]) async {
+  Future<List<Circle>> addCircles(List<CircleOptions> options,
+      [List<Map>? data]) async {
     final cricles = [
       for (var i = 0; i < options.length; i++)
-        Circle(getRandomString(), CircleOptions.defaultOptions.copyWith(options[i]), data?[i])
+        Circle(getRandomString(),
+            CircleOptions.defaultOptions.copyWith(options[i]), data?[i])
     ];
     await circleManager!.addAll(cricles);
 
@@ -819,7 +848,8 @@ class MapboxMapController extends ChangeNotifier {
   /// The returned [Future] completes with the added fill once listeners have
   /// been notified.
   Future<Fill> addFill(FillOptions options, [Map? data]) async {
-    final FillOptions effectiveOptions = FillOptions.defaultOptions.copyWith(options);
+    final FillOptions effectiveOptions =
+        FillOptions.defaultOptions.copyWith(options);
     final fill = Fill(getRandomString(), effectiveOptions, data);
     await fillManager!.add(fill);
     notifyListeners();
@@ -834,10 +864,12 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes with the added fills once listeners have
   /// been notified.
-  Future<List<Fill>> addFills(List<FillOptions> options, [List<Map>? data]) async {
+  Future<List<Fill>> addFills(List<FillOptions> options,
+      [List<Map>? data]) async {
     final fills = [
       for (var i = 0; i < options.length; i++)
-        Fill(getRandomString(), FillOptions.defaultOptions.copyWith(options[i]), data?[i])
+        Fill(getRandomString(), FillOptions.defaultOptions.copyWith(options[i]),
+            data?[i])
     ];
     await fillManager!.addAll(fills);
 
@@ -902,8 +934,10 @@ class MapboxMapController extends ChangeNotifier {
   }
 
   /// Query rendered features in a Rect in screen coordinates
-  Future<List> queryRenderedFeaturesInRect(Rect rect, List<String> layerIds, String? filter) async {
-    return _mapboxGlPlatform.queryRenderedFeaturesInRect(rect, layerIds, filter);
+  Future<List> queryRenderedFeaturesInRect(
+      Rect rect, List<String> layerIds, String? filter) async {
+    return _mapboxGlPlatform.queryRenderedFeaturesInRect(
+        rect, layerIds, filter);
   }
 
   Future invalidateAmbientCache() async {
@@ -982,7 +1016,8 @@ class MapboxMapController extends ChangeNotifier {
   }
 
   /// Adds an image source to the style currently displayed in the map, so that it can later be referred to by the provided id.
-  Future<void> addImageSource(String imageSourceId, Uint8List bytes, LatLngQuad coordinates) {
+  Future<void> addImageSource(
+      String imageSourceId, Uint8List bytes, LatLngQuad coordinates) {
     return _mapboxGlPlatform.addImageSource(imageSourceId, bytes, coordinates);
   }
 
@@ -1004,16 +1039,20 @@ class MapboxMapController extends ChangeNotifier {
   }
 
   /// Adds a Mapbox image layer below the layer provided with belowLayerId to the map's style at render time.
-  Future<void> addImageLayerBelow(String layerId, String sourceId, String imageSourceId,
+  Future<void> addImageLayerBelow(
+      String layerId, String sourceId, String imageSourceId,
       {double? minzoom, double? maxzoom}) {
-    return _mapboxGlPlatform.addLayerBelow(layerId, sourceId, imageSourceId, minzoom, maxzoom);
+    return _mapboxGlPlatform.addLayerBelow(
+        layerId, sourceId, imageSourceId, minzoom, maxzoom);
   }
 
   /// Adds a Mapbox image layer below the layer provided with belowLayerId to the map's style at render time. Only works for image sources!
   @Deprecated("This method was renamed to addImageLayerBelow for clarity.")
-  Future<void> addLayerBelow(String layerId, String sourceId, String imageSourceId,
+  Future<void> addLayerBelow(
+      String layerId, String sourceId, String imageSourceId,
       {double? minzoom, double? maxzoom}) {
-    return _mapboxGlPlatform.addLayerBelow(layerId, sourceId, imageSourceId, minzoom, maxzoom);
+    return _mapboxGlPlatform.addLayerBelow(
+        layerId, sourceId, imageSourceId, minzoom, maxzoom);
   }
 
   /// Removes a Mapbox style layer
@@ -1062,7 +1101,8 @@ class MapboxMapController extends ChangeNotifier {
   /// [HillshadeLayerProperties].
   /// [sourceLayer] is used to selected a specific source layer from Vector
   /// source.
-  Future<void> addLayer(String sourceId, String layerId, LayerProperties properties,
+  Future<void> addLayer(
+      String sourceId, String layerId, LayerProperties properties,
       {String? belowLayerId,
       bool enableInteraction = true,
       String? sourceLayer,
@@ -1098,10 +1138,16 @@ class MapboxMapController extends ChangeNotifier {
           maxzoom: maxzoom);
     } else if (properties is RasterLayerProperties) {
       addRasterLayer(sourceId, layerId, properties,
-          belowLayerId: belowLayerId, sourceLayer: sourceLayer, minzoom: minzoom, maxzoom: maxzoom);
+          belowLayerId: belowLayerId,
+          sourceLayer: sourceLayer,
+          minzoom: minzoom,
+          maxzoom: maxzoom);
     } else if (properties is HillshadeLayerProperties) {
       addHillshadeLayer(sourceId, layerId, properties,
-          belowLayerId: belowLayerId, sourceLayer: sourceLayer, minzoom: minzoom, maxzoom: maxzoom);
+          belowLayerId: belowLayerId,
+          sourceLayer: sourceLayer,
+          minzoom: minzoom,
+          maxzoom: maxzoom);
     } else {
       throw UnimplementedError("Unknown layer type $properties");
     }

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -6,14 +6,14 @@ part of mapbox_gl;
 
 typedef void OnMapClickCallback(Point<double> point, LatLng coordinates);
 
-typedef void OnFeatureInteractionCallback(
-    dynamic id, Point<double> point, LatLng coordinates);
+typedef void OnFeatureInteractionCallback(dynamic id, Point<double> point, LatLng coordinates);
 
 typedef void OnFeatureDragnCallback(dynamic id,
     {required Point<double> point,
     required LatLng origin,
     required LatLng current,
-    required LatLng delta});
+    required LatLng delta,
+    required DragEventType eventType});
 
 typedef void OnMapLongClickCallback(Point<double> point, LatLng coordinates);
 
@@ -64,8 +64,7 @@ class MapboxMapController extends ChangeNotifier {
     _cameraPosition = initialCameraPosition;
 
     _mapboxGlPlatform.onFeatureTappedPlatform.add((payload) {
-      for (final fun
-          in List<OnFeatureInteractionCallback>.from(onFeatureTapped)) {
+      for (final fun in List<OnFeatureInteractionCallback>.from(onFeatureTapped)) {
         fun(payload["id"], payload["point"], payload["latLng"]);
       }
     });
@@ -76,7 +75,8 @@ class MapboxMapController extends ChangeNotifier {
             point: payload["point"],
             origin: payload["origin"],
             current: payload["current"],
-            delta: payload["delta"]);
+            delta: payload["delta"],
+            eventType: payload["eventType"]);
       }
     });
 
@@ -107,20 +107,20 @@ class MapboxMapController extends ChangeNotifier {
         final enableInteraction = interactionEnabled.contains(type);
         switch (type) {
           case AnnotationType.fill:
-            fillManager = FillManager(this,
-                onTap: onFillTapped, enableInteraction: enableInteraction);
+            fillManager =
+                FillManager(this, onTap: onFillTapped, enableInteraction: enableInteraction);
             break;
           case AnnotationType.line:
-            lineManager = LineManager(this,
-                onTap: onLineTapped, enableInteraction: enableInteraction);
+            lineManager =
+                LineManager(this, onTap: onLineTapped, enableInteraction: enableInteraction);
             break;
           case AnnotationType.circle:
-            circleManager = CircleManager(this,
-                onTap: onCircleTapped, enableInteraction: enableInteraction);
+            circleManager =
+                CircleManager(this, onTap: onCircleTapped, enableInteraction: enableInteraction);
             break;
           case AnnotationType.symbol:
-            symbolManager = SymbolManager(this,
-                onTap: onSymbolTapped, enableInteraction: enableInteraction);
+            symbolManager =
+                SymbolManager(this, onTap: onSymbolTapped, enableInteraction: enableInteraction);
             break;
           default:
         }
@@ -205,8 +205,7 @@ class MapboxMapController extends ChangeNotifier {
 
   /// Callbacks to receive tap events for info windows on symbols
   @Deprecated("InfoWindow tapped is no longer supported")
-  final ArgumentCallbacks<Symbol> onInfoWindowTapped =
-      ArgumentCallbacks<Symbol>();
+  final ArgumentCallbacks<Symbol> onInfoWindowTapped = ArgumentCallbacks<Symbol>();
 
   /// The current set of symbols on this map.
   ///
@@ -288,8 +287,7 @@ class MapboxMapController extends ChangeNotifier {
   ///
   Future<void> addGeoJsonSource(String sourceId, Map<String, dynamic> geojson,
       {String? promoteId}) async {
-    await _mapboxGlPlatform.addGeoJsonSource(sourceId, geojson,
-        promoteId: promoteId);
+    await _mapboxGlPlatform.addGeoJsonSource(sourceId, geojson, promoteId: promoteId);
   }
 
   /// Sets new geojson data to and existing source
@@ -303,8 +301,7 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes after the change has been made on the
   /// platform side.
-  Future<void> setGeoJsonSource(
-      String sourceId, Map<String, dynamic> geojson) async {
+  Future<void> setGeoJsonSource(String sourceId, Map<String, dynamic> geojson) async {
     await _mapboxGlPlatform.setGeoJsonSource(sourceId, geojson);
   }
 
@@ -319,10 +316,8 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes after the change has been made on the
   /// platform side.
-  Future<void> setGeoJsonFeature(
-      String sourceId, Map<String, dynamic> geojsonFeature) async {
-    await _mapboxGlPlatform.setFeatureForGeoJsonSource(
-        sourceId, geojsonFeature);
+  Future<void> setGeoJsonFeature(String sourceId, Map<String, dynamic> geojsonFeature) async {
+    await _mapboxGlPlatform.setFeatureForGeoJsonSource(sourceId, geojsonFeature);
   }
 
   /// Add a symbol layer to the map with the given properties
@@ -336,8 +331,7 @@ class MapboxMapController extends ChangeNotifier {
   /// If [enableInteraction] is set the layer is considered for touch or drag
   /// events. [sourceLayer] is used to selected a specific source layer from
   /// Vector source
-  Future<void> addSymbolLayer(
-      String sourceId, String layerId, SymbolLayerProperties properties,
+  Future<void> addSymbolLayer(String sourceId, String layerId, SymbolLayerProperties properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -366,8 +360,7 @@ class MapboxMapController extends ChangeNotifier {
   /// If [enableInteraction] is set the layer is considered for touch or drag
   /// events. [sourceLayer] is used to selected a specific source layer from
   /// Vector source
-  Future<void> addLineLayer(
-      String sourceId, String layerId, LineLayerProperties properties,
+  Future<void> addLineLayer(String sourceId, String layerId, LineLayerProperties properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -396,8 +389,7 @@ class MapboxMapController extends ChangeNotifier {
   /// If [enableInteraction] is set the layer is considered for touch or drag
   /// events. [sourceLayer] is used to selected a specific source layer from
   /// Vector source
-  Future<void> addFillLayer(
-      String sourceId, String layerId, FillLayerProperties properties,
+  Future<void> addFillLayer(String sourceId, String layerId, FillLayerProperties properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -426,8 +418,7 @@ class MapboxMapController extends ChangeNotifier {
   /// If [enableInteraction] is set the layer is considered for touch or drag
   /// events. [sourceLayer] is used to selected a specific source layer from
   /// Vector source
-  Future<void> addCircleLayer(
-      String sourceId, String layerId, CircleLayerProperties properties,
+  Future<void> addCircleLayer(String sourceId, String layerId, CircleLayerProperties properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -455,12 +446,8 @@ class MapboxMapController extends ChangeNotifier {
   /// Setting [belowLayerId] adds the new layer below the given id.
   /// [sourceLayer] is used to selected a specific source layer from
   /// Raster source
-  Future<void> addRasterLayer(
-      String sourceId, String layerId, RasterLayerProperties properties,
-      {String? belowLayerId,
-      String? sourceLayer,
-      double? minzoom,
-      double? maxzoom}) async {
+  Future<void> addRasterLayer(String sourceId, String layerId, RasterLayerProperties properties,
+      {String? belowLayerId, String? sourceLayer, double? minzoom, double? maxzoom}) async {
     await _mapboxGlPlatform.addRasterLayer(
       sourceId,
       layerId,
@@ -484,10 +471,7 @@ class MapboxMapController extends ChangeNotifier {
   /// Raster source
   Future<void> addHillshadeLayer(
       String sourceId, String layerId, HillshadeLayerProperties properties,
-      {String? belowLayerId,
-      String? sourceLayer,
-      double? minzoom,
-      double? maxzoom}) async {
+      {String? belowLayerId, String? sourceLayer, double? minzoom, double? maxzoom}) async {
     await _mapboxGlPlatform.addHillshadeLayer(
       sourceId,
       layerId,
@@ -503,10 +487,8 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes after the change has been made on the
   /// platform side.
-  Future<void> updateMyLocationTrackingMode(
-      MyLocationTrackingMode myLocationTrackingMode) async {
-    return _mapboxGlPlatform
-        .updateMyLocationTrackingMode(myLocationTrackingMode);
+  Future<void> updateMyLocationTrackingMode(MyLocationTrackingMode myLocationTrackingMode) async {
+    return _mapboxGlPlatform.updateMyLocationTrackingMode(myLocationTrackingMode);
   }
 
   /// Updates the language of the map labels to match the device's language.
@@ -528,8 +510,7 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes after the change has been made on the
   /// platform side.
-  Future<void> updateContentInsets(EdgeInsets insets,
-      [bool animated = false]) async {
+  Future<void> updateContentInsets(EdgeInsets insets, [bool animated = false]) async {
     return _mapboxGlPlatform.updateContentInsets(insets, animated);
   }
 
@@ -582,12 +563,10 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes with the added symbol once listeners have
   /// been notified.
-  Future<List<Symbol>> addSymbols(List<SymbolOptions> options,
-      [List<Map>? data]) async {
+  Future<List<Symbol>> addSymbols(List<SymbolOptions> options, [List<Map>? data]) async {
     final symbols = [
       for (var i = 0; i < options.length; i++)
-        Symbol(getRandomString(),
-            SymbolOptions.defaultOptions.copyWith(options[i]), data?[i])
+        Symbol(getRandomString(), SymbolOptions.defaultOptions.copyWith(options[i]), data?[i])
     ];
     await symbolManager!.addAll(symbols);
 
@@ -603,8 +582,7 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes once listeners have been notified.
   Future<void> updateSymbol(Symbol symbol, SymbolOptions changes) async {
-    await symbolManager!
-        .set(symbol..options = symbol.options.copyWith(changes));
+    await symbolManager!.set(symbol..options = symbol.options.copyWith(changes));
 
     notifyListeners();
   }
@@ -673,12 +651,10 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes with the added line once listeners have
   /// been notified.
-  Future<List<Line>> addLines(List<LineOptions> options,
-      [List<Map>? data]) async {
+  Future<List<Line>> addLines(List<LineOptions> options, [List<Map>? data]) async {
     final lines = [
       for (var i = 0; i < options.length; i++)
-        Line(getRandomString(), LineOptions.defaultOptions.copyWith(options[i]),
-            data?[i])
+        Line(getRandomString(), LineOptions.defaultOptions.copyWith(options[i]), data?[i])
     ];
     await lineManager!.addAll(lines);
 
@@ -749,8 +725,7 @@ class MapboxMapController extends ChangeNotifier {
   /// The returned [Future] completes with the added circle once listeners have
   /// been notified.
   Future<Circle> addCircle(CircleOptions options, [Map? data]) async {
-    final CircleOptions effectiveOptions =
-        CircleOptions.defaultOptions.copyWith(options);
+    final CircleOptions effectiveOptions = CircleOptions.defaultOptions.copyWith(options);
     final circle = Circle(getRandomString(), effectiveOptions, data);
     await circleManager!.add(circle);
     notifyListeners();
@@ -765,12 +740,10 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes with the added circle once listeners have
   /// been notified.
-  Future<List<Circle>> addCircles(List<CircleOptions> options,
-      [List<Map>? data]) async {
+  Future<List<Circle>> addCircles(List<CircleOptions> options, [List<Map>? data]) async {
     final cricles = [
       for (var i = 0; i < options.length; i++)
-        Circle(getRandomString(),
-            CircleOptions.defaultOptions.copyWith(options[i]), data?[i])
+        Circle(getRandomString(), CircleOptions.defaultOptions.copyWith(options[i]), data?[i])
     ];
     await circleManager!.addAll(cricles);
 
@@ -844,8 +817,7 @@ class MapboxMapController extends ChangeNotifier {
   /// The returned [Future] completes with the added fill once listeners have
   /// been notified.
   Future<Fill> addFill(FillOptions options, [Map? data]) async {
-    final FillOptions effectiveOptions =
-        FillOptions.defaultOptions.copyWith(options);
+    final FillOptions effectiveOptions = FillOptions.defaultOptions.copyWith(options);
     final fill = Fill(getRandomString(), effectiveOptions, data);
     await fillManager!.add(fill);
     notifyListeners();
@@ -860,12 +832,10 @@ class MapboxMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes with the added fills once listeners have
   /// been notified.
-  Future<List<Fill>> addFills(List<FillOptions> options,
-      [List<Map>? data]) async {
+  Future<List<Fill>> addFills(List<FillOptions> options, [List<Map>? data]) async {
     final fills = [
       for (var i = 0; i < options.length; i++)
-        Fill(getRandomString(), FillOptions.defaultOptions.copyWith(options[i]),
-            data?[i])
+        Fill(getRandomString(), FillOptions.defaultOptions.copyWith(options[i]), data?[i])
     ];
     await fillManager!.addAll(fills);
 
@@ -930,10 +900,8 @@ class MapboxMapController extends ChangeNotifier {
   }
 
   /// Query rendered features in a Rect in screen coordinates
-  Future<List> queryRenderedFeaturesInRect(
-      Rect rect, List<String> layerIds, String? filter) async {
-    return _mapboxGlPlatform.queryRenderedFeaturesInRect(
-        rect, layerIds, filter);
+  Future<List> queryRenderedFeaturesInRect(Rect rect, List<String> layerIds, String? filter) async {
+    return _mapboxGlPlatform.queryRenderedFeaturesInRect(rect, layerIds, filter);
   }
 
   Future invalidateAmbientCache() async {
@@ -1012,8 +980,7 @@ class MapboxMapController extends ChangeNotifier {
   }
 
   /// Adds an image source to the style currently displayed in the map, so that it can later be referred to by the provided id.
-  Future<void> addImageSource(
-      String imageSourceId, Uint8List bytes, LatLngQuad coordinates) {
+  Future<void> addImageSource(String imageSourceId, Uint8List bytes, LatLngQuad coordinates) {
     return _mapboxGlPlatform.addImageSource(imageSourceId, bytes, coordinates);
   }
 
@@ -1035,20 +1002,16 @@ class MapboxMapController extends ChangeNotifier {
   }
 
   /// Adds a Mapbox image layer below the layer provided with belowLayerId to the map's style at render time.
-  Future<void> addImageLayerBelow(
-      String layerId, String sourceId, String imageSourceId,
+  Future<void> addImageLayerBelow(String layerId, String sourceId, String imageSourceId,
       {double? minzoom, double? maxzoom}) {
-    return _mapboxGlPlatform.addLayerBelow(
-        layerId, sourceId, imageSourceId, minzoom, maxzoom);
+    return _mapboxGlPlatform.addLayerBelow(layerId, sourceId, imageSourceId, minzoom, maxzoom);
   }
 
   /// Adds a Mapbox image layer below the layer provided with belowLayerId to the map's style at render time. Only works for image sources!
   @Deprecated("This method was renamed to addImageLayerBelow for clarity.")
-  Future<void> addLayerBelow(
-      String layerId, String sourceId, String imageSourceId,
+  Future<void> addLayerBelow(String layerId, String sourceId, String imageSourceId,
       {double? minzoom, double? maxzoom}) {
-    return _mapboxGlPlatform.addLayerBelow(
-        layerId, sourceId, imageSourceId, minzoom, maxzoom);
+    return _mapboxGlPlatform.addLayerBelow(layerId, sourceId, imageSourceId, minzoom, maxzoom);
   }
 
   /// Removes a Mapbox style layer
@@ -1097,8 +1060,7 @@ class MapboxMapController extends ChangeNotifier {
   /// [HillshadeLayerProperties].
   /// [sourceLayer] is used to selected a specific source layer from Vector
   /// source.
-  Future<void> addLayer(
-      String sourceId, String layerId, LayerProperties properties,
+  Future<void> addLayer(String sourceId, String layerId, LayerProperties properties,
       {String? belowLayerId,
       bool enableInteraction = true,
       String? sourceLayer,
@@ -1134,16 +1096,10 @@ class MapboxMapController extends ChangeNotifier {
           maxzoom: maxzoom);
     } else if (properties is RasterLayerProperties) {
       addRasterLayer(sourceId, layerId, properties,
-          belowLayerId: belowLayerId,
-          sourceLayer: sourceLayer,
-          minzoom: minzoom,
-          maxzoom: maxzoom);
+          belowLayerId: belowLayerId, sourceLayer: sourceLayer, minzoom: minzoom, maxzoom: maxzoom);
     } else if (properties is HillshadeLayerProperties) {
       addHillshadeLayer(sourceId, layerId, properties,
-          belowLayerId: belowLayerId,
-          sourceLayer: sourceLayer,
-          minzoom: minzoom,
-          maxzoom: maxzoom);
+          belowLayerId: belowLayerId, sourceLayer: sourceLayer, minzoom: minzoom, maxzoom: maxzoom);
     } else {
       throw UnimplementedError("Unknown layer type $properties");
     }

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -71,12 +71,14 @@ class MapboxMapController extends ChangeNotifier {
 
     _mapboxGlPlatform.onFeatureDraggedPlatform.add((payload) {
       for (final fun in List<OnFeatureDragnCallback>.from(onFeatureDrag)) {
+        final DragEventType enmDragEventType =
+            DragEventType.values.firstWhere((element) => element.name == payload["eventType"]);
         fun(payload["id"],
             point: payload["point"],
             origin: payload["origin"],
             current: payload["current"],
             delta: payload["delta"],
-            eventType: payload["eventType"]);
+            eventType: enmDragEventType);
       }
     });
 

--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -4,7 +4,8 @@
 
 part of mapbox_gl;
 
-final MethodChannel _globalChannel = MethodChannel('plugins.flutter.io/mapbox_gl');
+final MethodChannel _globalChannel =
+    MethodChannel('plugins.flutter.io/mapbox_gl');
 
 /// Copy tiles db file passed in to the tiles cache directory (sideloaded) to
 /// make tiles available offline.
@@ -92,7 +93,8 @@ Future<dynamic> setOfflineTileCountLimit(int limit, {String? accessToken}) =>
       },
     );
 
-Future<dynamic> deleteOfflineRegion(int id, {String? accessToken}) => _globalChannel.invokeMethod(
+Future<dynamic> deleteOfflineRegion(int id, {String? accessToken}) =>
+    _globalChannel.invokeMethod(
       'deleteOfflineRegion',
       <String, dynamic>{
         'id': id,
@@ -106,9 +108,11 @@ Future<OfflineRegion> downloadOfflineRegion(
   String? accessToken,
   Function(DownloadRegionStatus event)? onEvent,
 }) async {
-  String channelName = 'downloadOfflineRegion_${DateTime.now().microsecondsSinceEpoch}';
+  String channelName =
+      'downloadOfflineRegion_${DateTime.now().microsecondsSinceEpoch}';
 
-  final result = await _globalChannel.invokeMethod('downloadOfflineRegion', <String, dynamic>{
+  final result = await _globalChannel
+      .invokeMethod('downloadOfflineRegion', <String, dynamic>{
     'accessToken': accessToken,
     'channelName': channelName,
     'definition': definition.toMap(),
@@ -124,7 +128,8 @@ Future<OfflineRegion> downloadOfflineRegion(
       var unknownError = Error(
         PlatformException(
           code: 'UnknowException',
-          message: 'This error is unhandled by plugin. Please contact us if needed.',
+          message:
+              'This error is unhandled by plugin. Please contact us if needed.',
           details: error,
         ),
       );

--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -4,8 +4,7 @@
 
 part of mapbox_gl;
 
-final MethodChannel _globalChannel =
-    MethodChannel('plugins.flutter.io/mapbox_gl');
+final MethodChannel _globalChannel = MethodChannel('plugins.flutter.io/mapbox_gl');
 
 /// Copy tiles db file passed in to the tiles cache directory (sideloaded) to
 /// make tiles available offline.
@@ -17,6 +16,8 @@ Future<void> installOfflineMapTiles(String tilesDb) async {
     },
   );
 }
+
+enum DragEventType { start, drag, end }
 
 Future<dynamic> setOffline(
   bool offline, {
@@ -91,8 +92,7 @@ Future<dynamic> setOfflineTileCountLimit(int limit, {String? accessToken}) =>
       },
     );
 
-Future<dynamic> deleteOfflineRegion(int id, {String? accessToken}) =>
-    _globalChannel.invokeMethod(
+Future<dynamic> deleteOfflineRegion(int id, {String? accessToken}) => _globalChannel.invokeMethod(
       'deleteOfflineRegion',
       <String, dynamic>{
         'id': id,
@@ -106,11 +106,9 @@ Future<OfflineRegion> downloadOfflineRegion(
   String? accessToken,
   Function(DownloadRegionStatus event)? onEvent,
 }) async {
-  String channelName =
-      'downloadOfflineRegion_${DateTime.now().microsecondsSinceEpoch}';
+  String channelName = 'downloadOfflineRegion_${DateTime.now().microsecondsSinceEpoch}';
 
-  final result = await _globalChannel
-      .invokeMethod('downloadOfflineRegion', <String, dynamic>{
+  final result = await _globalChannel.invokeMethod('downloadOfflineRegion', <String, dynamic>{
     'accessToken': accessToken,
     'channelName': channelName,
     'definition': definition.toMap(),
@@ -126,8 +124,7 @@ Future<OfflineRegion> downloadOfflineRegion(
       var unknownError = Error(
         PlatformException(
           code: 'UnknowException',
-          message:
-              'This error is unhandled by plugin. Please contact us if needed.',
+          message: 'This error is unhandled by plugin. Please contact us if needed.',
           details: error,
         ),
       );

--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -1,6 +1,5 @@
 part of mapbox_gl_platform_interface;
 
-
 class MethodChannelMapboxGl extends MapboxGlPlatform {
   late MethodChannel _channel;
   static bool useHybridComposition = true;
@@ -38,9 +37,7 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
 
         final double deltaLat = call.arguments['deltaLat'];
         final double deltaLng = call.arguments['deltaLng'];
-        final String eventType= call.arguments['eventType'];
-
-
+        final String eventType = call.arguments['eventType'];
 
         onFeatureDraggedPlatform({
           'id': id,
@@ -48,7 +45,7 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
           'origin': LatLng(originLat, originLng),
           'current': LatLng(currentLat, currentLng),
           'delta': LatLng(deltaLat, deltaLng),
-          'eventType':eventType,
+          'eventType': eventType,
         });
         break;
 

--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -1,5 +1,11 @@
 part of mapbox_gl_platform_interface;
 
+enum DragEventType
+{
+  start,
+  drag,
+  end
+}
 class MethodChannelMapboxGl extends MapboxGlPlatform {
   late MethodChannel _channel;
   static bool useHybridComposition = true;
@@ -37,6 +43,10 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
 
         final double deltaLat = call.arguments['deltaLat'];
         final double deltaLng = call.arguments['deltaLng'];
+        final String eventType= call.arguments['eventType'];
+
+        final DragEventType enmDragEventType =
+            DragEventType.values.firstWhere((element) => element.name == eventType);
 
         onFeatureDraggedPlatform({
           'id': id,
@@ -44,6 +54,7 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
           'origin': LatLng(originLat, originLng),
           'current': LatLng(currentLat, currentLng),
           'delta': LatLng(deltaLat, deltaLng),
+          'eventType':enmDragEventType,
         });
         break;
 

--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -1,11 +1,6 @@
 part of mapbox_gl_platform_interface;
 
-enum DragEventType
-{
-  start,
-  drag,
-  end
-}
+
 class MethodChannelMapboxGl extends MapboxGlPlatform {
   late MethodChannel _channel;
   static bool useHybridComposition = true;
@@ -45,8 +40,7 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
         final double deltaLng = call.arguments['deltaLng'];
         final String eventType= call.arguments['eventType'];
 
-        final DragEventType enmDragEventType =
-            DragEventType.values.firstWhere((element) => element.name == eventType);
+
 
         onFeatureDraggedPlatform({
           'id': id,
@@ -54,7 +48,7 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
           'origin': LatLng(originLat, originLng),
           'current': LatLng(currentLat, currentLng),
           'delta': LatLng(deltaLat, deltaLng),
-          'eventType':enmDragEventType,
+          'eventType':eventType,
         });
         break;
 

--- a/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
+++ b/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
@@ -1,8 +1,10 @@
 part of mapbox_gl_web;
 
-const _mapboxGlCssUrl = 'https://api.mapbox.com/mapbox-gl-js/v2.7.0/mapbox-gl.css';
+const _mapboxGlCssUrl =
+    'https://api.mapbox.com/mapbox-gl-js/v2.7.0/mapbox-gl.css';
 
-class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSink {
+class MapboxWebGlPlatform extends MapboxGlPlatform
+    implements MapboxMapOptionsSink {
   late DivElement _mapElement;
 
   late Map<String, dynamic> _creationParams;
@@ -30,7 +32,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
       Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers) {
     _creationParams = creationParams;
     _registerViewFactory(onPlatformViewCreated, this.hashCode);
-    return HtmlElementView(viewType: 'plugins.flutter.io/mapbox_gl_${this.hashCode}');
+    return HtmlElementView(
+        viewType: 'plugins.flutter.io/mapbox_gl_${this.hashCode}');
   }
 
   @override
@@ -41,8 +44,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
 
   void _registerViewFactory(Function(int) callback, int identifier) {
     // ignore: undefined_prefixed_name
-    ui.platformViewRegistry.registerViewFactory('plugins.flutter.io/mapbox_gl_$identifier',
-        (int viewId) {
+    ui.platformViewRegistry.registerViewFactory(
+        'plugins.flutter.io/mapbox_gl_$identifier', (int viewId) {
       _mapElement = DivElement()
         ..style.width = '100%'
         ..style.height = '100%';
@@ -106,7 +109,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
       _dragOrigin = LatLng(coords.lat as double, coords.lng as double);
 
       if (_draggedFeatureId != null) {
-        final current = LatLng(e.lngLat.lat.toDouble(), e.lngLat.lng.toDouble());
+        final current =
+            LatLng(e.lngLat.lat.toDouble(), e.lngLat.lng.toDouble());
         final payload = {
           'id': _draggedFeatureId,
           'point': Point<double>(e.point.x.toDouble(), e.point.y.toDouble()),
@@ -165,7 +169,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
   }
 
   @override
-  Future<CameraPosition?> updateMapOptions(Map<String, dynamic> optionsUpdate) async {
+  Future<CameraPosition?> updateMapOptions(
+      Map<String, dynamic> optionsUpdate) async {
     // FIX: why is called indefinitely? (map_ui page)
     Convert.interpretMapboxMapOptions(optionsUpdate, this);
     return _getCameraPosition();
@@ -186,7 +191,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
   }
 
   @override
-  Future<void> updateMyLocationTrackingMode(MyLocationTrackingMode myLocationTrackingMode) async {
+  Future<void> updateMyLocationTrackingMode(
+      MyLocationTrackingMode myLocationTrackingMode) async {
     setMyLocationTrackingMode(myLocationTrackingMode.index);
   }
 
@@ -245,7 +251,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
   }
 
   @override
-  Future<List> queryRenderedFeaturesInRect(Rect rect, List<String> layerIds, String? filter) async {
+  Future<List> queryRenderedFeaturesInRect(
+      Rect rect, List<String> layerIds, String? filter) async {
     Map<String, dynamic> options = {};
     if (layerIds.length > 0) {
       options['layers'] = layerIds;
@@ -297,7 +304,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
   }
 
   @override
-  Future<void> addImage(String name, Uint8List bytes, [bool sdf = false]) async {
+  Future<void> addImage(String name, Uint8List bytes,
+      [bool sdf = false]) async {
     final photo = decodeImage(bytes)!;
     if (!_map.hasImage(name)) {
       _map.addImage(
@@ -349,8 +357,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
   }
 
   void _onMapClick(Event e) {
-    final features = _map.queryRenderedFeatures(
-        [e.point.x, e.point.y], {"layers": _interactiveFeatureLayerIds.toList()});
+    final features = _map.queryRenderedFeatures([e.point.x, e.point.y],
+        {"layers": _interactiveFeatureLayerIds.toList()});
     final payload = {
       'point': Point<double>(e.point.x.toDouble(), e.point.y.toDouble()),
       'latLng': LatLng(e.lngLat.lat.toDouble(), e.lngLat.lng.toDouble()),
@@ -613,21 +621,24 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
 
   @override
   Future<Point> toScreenLocation(LatLng latLng) async {
-    var screenPosition = _map.project(LngLat(latLng.longitude, latLng.latitude));
+    var screenPosition =
+        _map.project(LngLat(latLng.longitude, latLng.latitude));
     return Point(screenPosition.x.round(), screenPosition.y.round());
   }
 
   @override
   Future<List<Point>> toScreenLocationBatch(Iterable<LatLng> latLngs) async {
     return latLngs.map((latLng) {
-      var screenPosition = _map.project(LngLat(latLng.longitude, latLng.latitude));
+      var screenPosition =
+          _map.project(LngLat(latLng.longitude, latLng.latitude));
       return Point(screenPosition.x.round(), screenPosition.y.round());
     }).toList(growable: false);
   }
 
   @override
   Future<LatLng> toLatLng(Point screenLocation) async {
-    var lngLat = _map.unproject(mapbox.Point(screenLocation.x, screenLocation.y));
+    var lngLat =
+        _map.unproject(mapbox.Point(screenLocation.x, screenLocation.y));
     return LatLng(lngLat.lat as double, lngLat.lng as double);
   }
 
@@ -672,7 +683,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
   }
 
   @override
-  Future<void> setGeoJsonSource(String sourceId, Map<String, dynamic> geojson) async {
+  Future<void> setGeoJsonSource(
+      String sourceId, Map<String, dynamic> geojson) async {
     final source = _map.getSource(sourceId) as GeoJsonSource;
     final data = _makeFeatureCollection(geojson);
     _addedFeaturesByLayer[sourceId] = data;
@@ -680,7 +692,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
   }
 
   @override
-  Future<void> addCircleLayer(String sourceId, String layerId, Map<String, dynamic> properties,
+  Future<void> addCircleLayer(
+      String sourceId, String layerId, Map<String, dynamic> properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -695,7 +708,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
   }
 
   @override
-  Future<void> addFillLayer(String sourceId, String layerId, Map<String, dynamic> properties,
+  Future<void> addFillLayer(
+      String sourceId, String layerId, Map<String, dynamic> properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -710,7 +724,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
   }
 
   @override
-  Future<void> addLineLayer(String sourceId, String layerId, Map<String, dynamic> properties,
+  Future<void> addLineLayer(
+      String sourceId, String layerId, Map<String, dynamic> properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -725,7 +740,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
   }
 
   @override
-  Future<void> addSymbolLayer(String sourceId, String layerId, Map<String, dynamic> properties,
+  Future<void> addSymbolLayer(
+      String sourceId, String layerId, Map<String, dynamic> properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -740,8 +756,12 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
   }
 
   @override
-  Future<void> addHillshadeLayer(String sourceId, String layerId, Map<String, dynamic> properties,
-      {String? belowLayerId, String? sourceLayer, double? minzoom, double? maxzoom}) async {
+  Future<void> addHillshadeLayer(
+      String sourceId, String layerId, Map<String, dynamic> properties,
+      {String? belowLayerId,
+      String? sourceLayer,
+      double? minzoom,
+      double? maxzoom}) async {
     return _addLayer(sourceId, layerId, properties, "hillshade",
         belowLayerId: belowLayerId,
         sourceLayer: sourceLayer,
@@ -751,8 +771,12 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
   }
 
   @override
-  Future<void> addRasterLayer(String sourceId, String layerId, Map<String, dynamic> properties,
-      {String? belowLayerId, String? sourceLayer, double? minzoom, double? maxzoom}) async {
+  Future<void> addRasterLayer(
+      String sourceId, String layerId, Map<String, dynamic> properties,
+      {String? belowLayerId,
+      String? sourceLayer,
+      double? minzoom,
+      double? maxzoom}) async {
     await _addLayer(sourceId, layerId, properties, "raster",
         belowLayerId: belowLayerId,
         sourceLayer: sourceLayer,
@@ -761,17 +785,17 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
         enableInteraction: false);
   }
 
-  Future<void> _addLayer(
-      String sourceId, String layerId, Map<String, dynamic> properties, String layerType,
+  Future<void> _addLayer(String sourceId, String layerId,
+      Map<String, dynamic> properties, String layerType,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
       double? maxzoom,
       required bool enableInteraction}) async {
-    final layout =
-        Map.fromEntries(properties.entries.where((entry) => isLayoutProperty(entry.key)));
-    final paint =
-        Map.fromEntries(properties.entries.where((entry) => !isLayoutProperty(entry.key)));
+    final layout = Map.fromEntries(
+        properties.entries.where((entry) => isLayoutProperty(entry.key)));
+    final paint = Map.fromEntries(
+        properties.entries.where((entry) => !isLayoutProperty(entry.key)));
 
     _map.addLayer({
       'id': layerId,
@@ -865,21 +889,22 @@ class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSi
     _map.addSource(sourceId, source.toJson());
   }
 
-  Future<void> addImageSource(String imageSourceId, Uint8List bytes, LatLngQuad coordinates) {
+  Future<void> addImageSource(
+      String imageSourceId, Uint8List bytes, LatLngQuad coordinates) {
     // TODO: implement addImageSource
     throw UnimplementedError();
   }
 
   @override
-  Future<void> addLayer(
-      String imageLayerId, String imageSourceId, double? minzoom, double? maxzoom) {
+  Future<void> addLayer(String imageLayerId, String imageSourceId,
+      double? minzoom, double? maxzoom) {
     // TODO: implement addLayer
     throw UnimplementedError();
   }
 
   @override
-  Future<void> addLayerBelow(String imageLayerId, String imageSourceId, String belowLayerId,
-      double? minzoom, double? maxzoom) {
+  Future<void> addLayerBelow(String imageLayerId, String imageSourceId,
+      String belowLayerId, double? minzoom, double? maxzoom) {
     // TODO: implement addLayerBelow
     throw UnimplementedError();
   }

--- a/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
+++ b/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
@@ -1,10 +1,8 @@
 part of mapbox_gl_web;
 
-const _mapboxGlCssUrl =
-    'https://api.mapbox.com/mapbox-gl-js/v2.7.0/mapbox-gl.css';
+const _mapboxGlCssUrl = 'https://api.mapbox.com/mapbox-gl-js/v2.7.0/mapbox-gl.css';
 
-class MapboxWebGlPlatform extends MapboxGlPlatform
-    implements MapboxMapOptionsSink {
+class MapboxWebGlPlatform extends MapboxGlPlatform implements MapboxMapOptionsSink {
   late DivElement _mapElement;
 
   late Map<String, dynamic> _creationParams;
@@ -32,8 +30,7 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
       Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers) {
     _creationParams = creationParams;
     _registerViewFactory(onPlatformViewCreated, this.hashCode);
-    return HtmlElementView(
-        viewType: 'plugins.flutter.io/mapbox_gl_${this.hashCode}');
+    return HtmlElementView(viewType: 'plugins.flutter.io/mapbox_gl_${this.hashCode}');
   }
 
   @override
@@ -44,8 +41,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
 
   void _registerViewFactory(Function(int) callback, int identifier) {
     // ignore: undefined_prefixed_name
-    ui.platformViewRegistry.registerViewFactory(
-        'plugins.flutter.io/mapbox_gl_$identifier', (int viewId) {
+    ui.platformViewRegistry.registerViewFactory('plugins.flutter.io/mapbox_gl_$identifier',
+        (int viewId) {
       _mapElement = DivElement()
         ..style.width = '100%'
         ..style.height = '100%';
@@ -107,10 +104,35 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
       _map.getCanvas().style.cursor = 'grabbing';
       var coords = e.lngLat;
       _dragOrigin = LatLng(coords.lat as double, coords.lng as double);
+
+      if (_draggedFeatureId != null) {
+        final current = LatLng(e.lngLat.lat.toDouble(), e.lngLat.lng.toDouble());
+        final payload = {
+          'id': _draggedFeatureId,
+          'point': Point<double>(e.point.x.toDouble(), e.point.y.toDouble()),
+          'origin': _dragOrigin,
+          'current': current,
+          'delta': LatLng(0, 0),
+          'eventType': 'start'
+        };
+        onFeatureDraggedPlatform(payload);
+      }
     }
   }
 
   _onMouseUp(Event e) {
+    if (_draggedFeatureId != null) {
+      final current = LatLng(e.lngLat.lat.toDouble(), e.lngLat.lng.toDouble());
+      final payload = {
+        'id': _draggedFeatureId,
+        'point': Point<double>(e.point.x.toDouble(), e.point.y.toDouble()),
+        'origin': _dragOrigin,
+        'current': current,
+        'delta': current - (_dragPrevious ?? _dragOrigin!),
+        'eventType': 'end'
+      };
+      onFeatureDraggedPlatform(payload);
+    }
     _draggedFeatureId = null;
     _dragPrevious = null;
     _dragOrigin = null;
@@ -126,6 +148,7 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
         'origin': _dragOrigin,
         'current': current,
         'delta': current - (_dragPrevious ?? _dragOrigin!),
+        'eventType': 'drag'
       };
       _dragPrevious = current;
       onFeatureDraggedPlatform(payload);
@@ -142,8 +165,7 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
   }
 
   @override
-  Future<CameraPosition?> updateMapOptions(
-      Map<String, dynamic> optionsUpdate) async {
+  Future<CameraPosition?> updateMapOptions(Map<String, dynamic> optionsUpdate) async {
     // FIX: why is called indefinitely? (map_ui page)
     Convert.interpretMapboxMapOptions(optionsUpdate, this);
     return _getCameraPosition();
@@ -164,8 +186,7 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
   }
 
   @override
-  Future<void> updateMyLocationTrackingMode(
-      MyLocationTrackingMode myLocationTrackingMode) async {
+  Future<void> updateMyLocationTrackingMode(MyLocationTrackingMode myLocationTrackingMode) async {
     setMyLocationTrackingMode(myLocationTrackingMode.index);
   }
 
@@ -224,8 +245,7 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
   }
 
   @override
-  Future<List> queryRenderedFeaturesInRect(
-      Rect rect, List<String> layerIds, String? filter) async {
+  Future<List> queryRenderedFeaturesInRect(Rect rect, List<String> layerIds, String? filter) async {
     Map<String, dynamic> options = {};
     if (layerIds.length > 0) {
       options['layers'] = layerIds;
@@ -277,8 +297,7 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
   }
 
   @override
-  Future<void> addImage(String name, Uint8List bytes,
-      [bool sdf = false]) async {
+  Future<void> addImage(String name, Uint8List bytes, [bool sdf = false]) async {
     final photo = decodeImage(bytes)!;
     if (!_map.hasImage(name)) {
       _map.addImage(
@@ -330,8 +349,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
   }
 
   void _onMapClick(Event e) {
-    final features = _map.queryRenderedFeatures([e.point.x, e.point.y],
-        {"layers": _interactiveFeatureLayerIds.toList()});
+    final features = _map.queryRenderedFeatures(
+        [e.point.x, e.point.y], {"layers": _interactiveFeatureLayerIds.toList()});
     final payload = {
       'point': Point<double>(e.point.x.toDouble(), e.point.y.toDouble()),
       'latLng': LatLng(e.lngLat.lat.toDouble(), e.lngLat.lng.toDouble()),
@@ -594,24 +613,21 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
 
   @override
   Future<Point> toScreenLocation(LatLng latLng) async {
-    var screenPosition =
-        _map.project(LngLat(latLng.longitude, latLng.latitude));
+    var screenPosition = _map.project(LngLat(latLng.longitude, latLng.latitude));
     return Point(screenPosition.x.round(), screenPosition.y.round());
   }
 
   @override
   Future<List<Point>> toScreenLocationBatch(Iterable<LatLng> latLngs) async {
     return latLngs.map((latLng) {
-      var screenPosition =
-          _map.project(LngLat(latLng.longitude, latLng.latitude));
+      var screenPosition = _map.project(LngLat(latLng.longitude, latLng.latitude));
       return Point(screenPosition.x.round(), screenPosition.y.round());
     }).toList(growable: false);
   }
 
   @override
   Future<LatLng> toLatLng(Point screenLocation) async {
-    var lngLat =
-        _map.unproject(mapbox.Point(screenLocation.x, screenLocation.y));
+    var lngLat = _map.unproject(mapbox.Point(screenLocation.x, screenLocation.y));
     return LatLng(lngLat.lat as double, lngLat.lng as double);
   }
 
@@ -656,8 +672,7 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
   }
 
   @override
-  Future<void> setGeoJsonSource(
-      String sourceId, Map<String, dynamic> geojson) async {
+  Future<void> setGeoJsonSource(String sourceId, Map<String, dynamic> geojson) async {
     final source = _map.getSource(sourceId) as GeoJsonSource;
     final data = _makeFeatureCollection(geojson);
     _addedFeaturesByLayer[sourceId] = data;
@@ -665,8 +680,7 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
   }
 
   @override
-  Future<void> addCircleLayer(
-      String sourceId, String layerId, Map<String, dynamic> properties,
+  Future<void> addCircleLayer(String sourceId, String layerId, Map<String, dynamic> properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -681,8 +695,7 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
   }
 
   @override
-  Future<void> addFillLayer(
-      String sourceId, String layerId, Map<String, dynamic> properties,
+  Future<void> addFillLayer(String sourceId, String layerId, Map<String, dynamic> properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -697,8 +710,7 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
   }
 
   @override
-  Future<void> addLineLayer(
-      String sourceId, String layerId, Map<String, dynamic> properties,
+  Future<void> addLineLayer(String sourceId, String layerId, Map<String, dynamic> properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -713,8 +725,7 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
   }
 
   @override
-  Future<void> addSymbolLayer(
-      String sourceId, String layerId, Map<String, dynamic> properties,
+  Future<void> addSymbolLayer(String sourceId, String layerId, Map<String, dynamic> properties,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
@@ -729,12 +740,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
   }
 
   @override
-  Future<void> addHillshadeLayer(
-      String sourceId, String layerId, Map<String, dynamic> properties,
-      {String? belowLayerId,
-      String? sourceLayer,
-      double? minzoom,
-      double? maxzoom}) async {
+  Future<void> addHillshadeLayer(String sourceId, String layerId, Map<String, dynamic> properties,
+      {String? belowLayerId, String? sourceLayer, double? minzoom, double? maxzoom}) async {
     return _addLayer(sourceId, layerId, properties, "hillshade",
         belowLayerId: belowLayerId,
         sourceLayer: sourceLayer,
@@ -744,12 +751,8 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
   }
 
   @override
-  Future<void> addRasterLayer(
-      String sourceId, String layerId, Map<String, dynamic> properties,
-      {String? belowLayerId,
-      String? sourceLayer,
-      double? minzoom,
-      double? maxzoom}) async {
+  Future<void> addRasterLayer(String sourceId, String layerId, Map<String, dynamic> properties,
+      {String? belowLayerId, String? sourceLayer, double? minzoom, double? maxzoom}) async {
     await _addLayer(sourceId, layerId, properties, "raster",
         belowLayerId: belowLayerId,
         sourceLayer: sourceLayer,
@@ -758,17 +761,17 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
         enableInteraction: false);
   }
 
-  Future<void> _addLayer(String sourceId, String layerId,
-      Map<String, dynamic> properties, String layerType,
+  Future<void> _addLayer(
+      String sourceId, String layerId, Map<String, dynamic> properties, String layerType,
       {String? belowLayerId,
       String? sourceLayer,
       double? minzoom,
       double? maxzoom,
       required bool enableInteraction}) async {
-    final layout = Map.fromEntries(
-        properties.entries.where((entry) => isLayoutProperty(entry.key)));
-    final paint = Map.fromEntries(
-        properties.entries.where((entry) => !isLayoutProperty(entry.key)));
+    final layout =
+        Map.fromEntries(properties.entries.where((entry) => isLayoutProperty(entry.key)));
+    final paint =
+        Map.fromEntries(properties.entries.where((entry) => !isLayoutProperty(entry.key)));
 
     _map.addLayer({
       'id': layerId,
@@ -862,22 +865,21 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
     _map.addSource(sourceId, source.toJson());
   }
 
-  Future<void> addImageSource(
-      String imageSourceId, Uint8List bytes, LatLngQuad coordinates) {
+  Future<void> addImageSource(String imageSourceId, Uint8List bytes, LatLngQuad coordinates) {
     // TODO: implement addImageSource
     throw UnimplementedError();
   }
 
   @override
-  Future<void> addLayer(String imageLayerId, String imageSourceId,
-      double? minzoom, double? maxzoom) {
+  Future<void> addLayer(
+      String imageLayerId, String imageSourceId, double? minzoom, double? maxzoom) {
     // TODO: implement addLayer
     throw UnimplementedError();
   }
 
   @override
-  Future<void> addLayerBelow(String imageLayerId, String imageSourceId,
-      String belowLayerId, double? minzoom, double? maxzoom) {
+  Future<void> addLayerBelow(String imageLayerId, String imageSourceId, String belowLayerId,
+      double? minzoom, double? maxzoom) {
     // TODO: implement addLayerBelow
     throw UnimplementedError();
   }


### PR DESCRIPTION
onFeatureDrag was fired only when dragging the feature. Along with this PR, onFeatureDrag is also fired at the start and end of the drag. The event type is added to the payload with an enumeration.
```

  void _onMapCreated(MapboxMapController controller) {
    this.controller = controller;
    controller.onFillTapped.add(_onFillTapped);
    this.controller!.onFeatureDrag.add(_onFeatureDrag);
  }

  void _onFeatureDrag(id,
      {required current, required delta, required origin, required point, required eventType}) {
    DragEventType type = eventType;
    switch (type) {
      case DragEventType.start:
        // TODO: Handle this case.
        break;
      case DragEventType.drag:
        // TODO: Handle this case.
        break;
      case DragEventType.end:
        // TODO: Handle this case.
        break;
    }
  }
```