### PR TITLE
Do not create controller, Flutter 3 already does that internally

### DIFF
--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -172,7 +172,6 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
               onPlatformViewCreated,
             );
 
-            controller.create();
             return controller;
           },
         );


### PR DESCRIPTION
A possible fix for https://github.com/flutter-mapbox-gl/maps/issues/1119.
Looks like due to some changes in Flutter with Flutter 3, calling `create` is no longer required.
More testing is needed, everybody is welcome to check the issue against this branch.