### PR TITLE
Implement clusterProperties

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/SourcePropertyConverter.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/SourcePropertyConverter.java
@@ -6,6 +6,7 @@ import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngQuad;
 import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.style.sources.ImageSource;
@@ -86,6 +87,15 @@ class SourcePropertyConverter {
     final Object clusterRadius = data.get("clusterRadius");
     if (clusterRadius != null) {
       options = options.withClusterRadius(Convert.toInt(clusterRadius));
+    }
+
+    final Object clusterProperties = data.get("clusterProperties");
+    if (clusterProperties != null) {
+      for (Map.Entry<String, List> entry : ((Map<String, List>)Convert.toMap(clusterProperties)).entrySet()) {
+        Expression operatorExpr = Expression.Converter.convert(entry.getValue().get(0).toString());
+        Expression mapExpr = Expression.Converter.convert(entry.getValue().get(1).toString());
+        options = options.withClusterProperty(entry.getKey(), operatorExpr, mapExpr);
+      }
     }
 
     final Object lineMetrics = data.get("lineMetrics");

--- a/android/src/main/java/com/mapbox/mapboxgl/SourcePropertyConverter.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/SourcePropertyConverter.java
@@ -91,8 +91,12 @@ class SourcePropertyConverter {
 
     final Object clusterProperties = data.get("clusterProperties");
     if (clusterProperties != null) {
-      for (Map.Entry<String, List> entry : ((Map<String, List>)Convert.toMap(clusterProperties)).entrySet()) {
-        Expression operatorExpr = Expression.Converter.convert(entry.getValue().get(0).toString());
+      for (Map.Entry<String, List> entry : ((Map<String, List>) Convert.toMap(clusterProperties)).entrySet()) {
+        Expression operatorExpr;
+        if (entry.getValue().get(0) instanceof String)
+          operatorExpr = Expression.literal(entry.getValue().get(0));
+        else
+          operatorExpr = Expression.Converter.convert(entry.getValue().get(0).toString());
         Expression mapExpr = Expression.Converter.convert(entry.getValue().get(1).toString());
         options = options.withClusterProperty(entry.getKey(), operatorExpr, mapExpr);
       }

--- a/example/lib/sources.dart
+++ b/example/lib/sources.dart
@@ -99,6 +99,56 @@ class FullMapState extends State<FullMap> {
         ));
   }
 
+  static Future<void> addGeojsonClusterWithClusterProperty(MapboxMapController controller) async {
+    await controller.addSource(
+      "earthquakes",
+      GeojsonSourceProperties(
+        data: 'https://docs.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson',
+        cluster: true,
+        clusterMaxZoom: 14, // Max zoom to cluster points on
+        clusterRadius: 50, // Radius of each cluster when clustering points (defaults to 50)
+        clusterProperties: {
+          "totalMagnitude": [
+            "+",
+            ["get", "mag"]
+          ],
+        },
+      ),
+    );
+    await controller.addLayer(
+        "earthquakes",
+        "earthquakes-circles",
+        CircleLayerProperties(circleColor: [
+          Expressions.step,
+          [Expressions.get, 'totalMagnitude'],
+          '#51bbd6',
+          100,
+          '#f1f075',
+          750,
+          '#f28cb1'
+        ], circleRadius: [
+          Expressions.step,
+          [Expressions.get, 'totalMagnitude'],
+          20,
+          100,
+          30,
+          750,
+          40
+        ]));
+    await controller.addLayer(
+        "earthquakes",
+        "earthquakes-count",
+        SymbolLayerProperties(
+          textField: [
+            Expressions.numberFormat,
+            [Expressions.get, 'totalMagnitude'],
+            {'max-fraction-digits': 1}
+          ],
+          textFont: ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
+          textSize: 12,
+        ));
+  }
+
   static Future<void> addVector(MapboxMapController controller) async {
     await controller.addSource(
         "terrain",
@@ -189,6 +239,12 @@ class FullMapState extends State<FullMap> {
       name: "Geojson cluster",
       baseStyle: MapboxStyles.LIGHT,
       addDetails: addGeojsonCluster,
+      position: CameraPosition(target: LatLng(33.5, -118.1), zoom: 5),
+    ),
+    StyleInfo(
+      name: "Geojson cluster accumulated",
+      baseStyle: MapboxStyles.LIGHT,
+      addDetails: addGeojsonClusterWithClusterProperty,
       position: CameraPosition(target: LatLng(33.5, -118.1), zoom: 5),
     ),
     StyleInfo(

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -1310,7 +1310,6 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             let source = MGLShapeSource(identifier: sourceId, shape: parsed, options: [:])
             addedShapesByLayer[sourceId] = parsed
             mapView.style?.addSource(source)
-            print(source)
         } catch {}
     }
 

--- a/ios/Classes/SourcePropertyConverter.swift
+++ b/ios/Classes/SourcePropertyConverter.swift
@@ -98,9 +98,15 @@ class SourcePropertyConverter {
         if let clusterMaxZoom = properties["clusterMaxZoom"] as? Double {
             options[.maximumZoomLevelForClustering] = clusterMaxZoom
         }
-
-        // TODO: clusterProperties not implemneted for IOS
-
+        if let ccProperties = properties["clusterProperties"] as? [NSString: [Any]] {
+            var cProperties = [NSString: Any]()
+            for (key, value) in ccProperties {
+                let operatorExpr = NSExpression(format: "sum:({$featureAccumulated, \(key)})")
+                let mapExpr = NSExpression(mglJSONObject: value[1])
+                cProperties[key] = [operatorExpr, mapExpr]
+            }
+            options[.clusterProperties] = cProperties
+        }
         if let lineMetrics = properties["lineMetrics"] as? Bool {
             options[.lineDistanceMetrics] = lineMetrics
         }


### PR DESCRIPTION
The `clusterProperties` setting is provided in the `addSource` method on the `MapboxMapController`, but didnt work because it is not passed to the respective platform sdk. This should be fixed with this PR.

- [x] Implement Android
- [ ] Implement iOS
- [ ] Implement JS
- [x] Add showcase example
- [ ] Format & Cleanup