### PR TITLE
Mutable http headers

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Map;
+import java.util.List;
 
 class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
   private static final String TAG = GlobalMethodHandler.class.getSimpleName();
@@ -92,8 +93,13 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
         break;
       case "setHttpHeaders":
         Map<String, String> headers = (Map<String, String>) methodCall.argument("headers");
-        MapboxHttpRequestUtil.setHttpHeaders(headers, result);
+        List<String> filter = (List<String>) methodCall.argument("filter");
+        MapboxHttpRequestUtil.setHttpHeaders(headers, filter, result);
         break;
+      case "getHttpHeaders": {
+        MapboxHttpRequestUtil.getHttpHeaders(result);
+        break;
+      }
       case "downloadOfflineRegion":
         // Get args from caller
         Map<String, Object> definitionMap = (Map<String, Object>) methodCall.argument("definition");

--- a/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
@@ -18,8 +18,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 
 class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
   private static final String TAG = GlobalMethodHandler.class.getSimpleName();
@@ -96,10 +96,11 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
         List<String> filter = (List<String>) methodCall.argument("filter");
         MapboxHttpRequestUtil.setHttpHeaders(headers, filter, result);
         break;
-      case "getHttpHeaders": {
-        MapboxHttpRequestUtil.getHttpHeaders(result);
-        break;
-      }
+      case "getHttpHeaders":
+        {
+          MapboxHttpRequestUtil.getHttpHeaders(result);
+          break;
+        }
       case "downloadOfflineRegion":
         // Get args from caller
         Map<String, Object> definitionMap = (Map<String, Object>) methodCall.argument("definition");

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxHttpRequestUtil.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxHttpRequestUtil.java
@@ -3,31 +3,54 @@ package com.mapbox.mapboxgl;
 import com.mapbox.mapboxsdk.module.http.HttpRequestUtil;
 import io.flutter.plugin.common.MethodChannel;
 import java.util.Map;
+import java.util.List;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 
 abstract class MapboxHttpRequestUtil {
 
-  public static void setHttpHeaders(Map<String, String> headers, MethodChannel.Result result) {
-    HttpRequestUtil.setOkHttpClient(getOkHttpClient(headers, result).build());
+  public static void setHttpHeaders(Map<String, String> headers, List<String> filter, MethodChannel.Result result) {
+    HttpRequestUtil.setOkHttpClient(getOkHttpClient(headers, filter, result).build());
+    MapboxHttpRequestUtil.headers = headers;
+    MapboxHttpRequestUtil.filter = filter;
     result.success(null);
   }
 
+  public static void getHttpHeader(MethodChannel.Result result) {
+    result(MapboxHttpRequestUtil.headers);
+  }
+
+  private static Map<String, String> headers = null;
+  private static List<String> filter = null;
+
   private static OkHttpClient.Builder getOkHttpClient(
-      Map<String, String> headers, MethodChannel.Result result) {
+      Map<String, String> headers, List<String> filter, MethodChannel.Result result) {
     try {
       return new OkHttpClient.Builder()
           .addNetworkInterceptor(
               chain -> {
-                Request.Builder builder = chain.request().newBuilder();
-                for (Map.Entry<String, String> header : headers.entrySet()) {
-                  if (header.getKey() == null || header.getKey().trim().isEmpty()) {
-                    continue;
+                Request request = chain.request();
+                Request.Builder builder = request.newBuilder();
+                boolean useHeaders = true;
+                if (filter != null) {
+                  useHeaders = false;
+                  for (String pattern : filter) {
+                    if (request.url().toString().contains(pattern)) {
+                      useHeaders = true;
+                      break;
+                    }
                   }
-                  if (header.getValue() == null || header.getValue().trim().isEmpty()) {
-                    builder.removeHeader(header.getKey());
-                  } else {
-                    builder.header(header.getKey(), header.getValue());
+                }
+                if (useHeaders) {
+                  for (Map.Entry<String, String> header : headers.entrySet()) {
+                    if (header.getKey() == null || header.getKey().trim().isEmpty()) {
+                      continue;
+                    }
+                    if (header.getValue() == null || header.getValue().trim().isEmpty()) {
+                      builder.removeHeader(header.getKey());
+                    } else {
+                      builder.header(header.getKey(), header.getValue());
+                    }
                   }
                 }
                 return chain.proceed(builder.build());

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxHttpRequestUtil.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxHttpRequestUtil.java
@@ -2,14 +2,15 @@ package com.mapbox.mapboxgl;
 
 import com.mapbox.mapboxsdk.module.http.HttpRequestUtil;
 import io.flutter.plugin.common.MethodChannel;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 
 abstract class MapboxHttpRequestUtil {
 
-  public static void setHttpHeaders(Map<String, String> headers, List<String> filter, MethodChannel.Result result) {
+  public static void setHttpHeaders(
+      Map<String, String> headers, List<String> filter, MethodChannel.Result result) {
     HttpRequestUtil.setOkHttpClient(getOkHttpClient(headers, filter, result).build());
     MapboxHttpRequestUtil.headers = headers;
     MapboxHttpRequestUtil.filter = filter;

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,8 @@
     <application
         android:name="${applicationName}"
         android:label="mapbox_gl_example"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
 
         <activity
             android:name=".MainActivity"

--- a/example/lib/http_headers.dart
+++ b/example/lib/http_headers.dart
@@ -1,0 +1,150 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:mapbox_gl/mapbox_gl.dart';
+
+import 'main.dart';
+import 'page.dart';
+
+class HttpHeadersPage extends ExamplePage {
+  HttpHeadersPage() : super(const Icon(Icons.map), 'HTTP headers');
+
+  @override
+  Widget build(BuildContext context) {
+    return const HttpHeaders();
+  }
+}
+
+class HttpHeaders extends StatefulWidget {
+  const HttpHeaders();
+
+  @override
+  State createState() => _HttpHeadersState();
+}
+
+class _HttpHeadersState extends State<HttpHeaders> {
+  MapboxMapController? mapController;
+  HttpServer? server;
+  StreamSubscription<HttpRequest>? subscription;
+  late Random _random;
+  late String _customAccessToken;
+
+  @override
+  initState() {
+    super.initState();
+
+    _random = Random();
+    _customAccessToken = _getRandomAccessToken();
+    setHttpHeaders({_authorizationHeader: 'Bearer $_customAccessToken'}, allowMutableHeadersAndFilterOnIOS: true);
+
+    HttpServer.bind(_localServerAddress, _localServerPort).then((server) {
+      setState(() {
+        this.server = server;
+        subscription = server.listen(_onRequestRecieved);
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    subscription?.cancel();
+    server?.close();
+    super.dispose();
+  }
+
+  void _onMapCreated(MapboxMapController controller) {
+    mapController = controller;
+  }
+
+  void _onRequestRecieved(HttpRequest request) {
+    final authorizationHeader = request.headers.value(_authorizationHeader);
+    if (authorizationHeader?.contains(_customAccessToken) ?? false) {
+      print("Authorized for ${request.uri.path}: $_customAccessToken");
+      if (request.uri.path.contains('style.json')) {
+        request.response.statusCode = 200;
+        request.response.write(_customStyle);
+        request.response.close();
+        return;
+      } else if (request.uri.path.contains('.pbf') ||
+          request.uri.path.contains('sprites')) {        
+        request.response.statusCode = 200;
+        request.response.close();
+        return;
+      }
+    }
+    print("Unauthorized for ${request.uri.path}: Expected $_customAccessToken, got $authorizationHeader");
+    request.response.statusCode = 401;
+    request.response.close();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (server == null) {
+      return Container(child: Text("Loading local server ..."));
+    }
+    return new Scaffold(
+      body: MapboxMap(
+        accessToken: MapsDemo.ACCESS_TOKEN,
+        styleString: 'http://$_localServerAddress:$_localServerPort/style.json',
+        onMapCreated: _onMapCreated,
+        initialCameraPosition: const CameraPosition(target: LatLng(0.0, 0.0)),
+        onStyleLoadedCallback: onStyleLoadedCallback,
+        gestureRecognizers:
+                          <Factory<OneSequenceGestureRecognizer>>[
+                        Factory<OneSequenceGestureRecognizer>(
+                          () => EagerGestureRecognizer(),
+                        ),
+                      ].toSet(),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          _customAccessToken = _getRandomAccessToken();
+          print("Reported headers: ${await getHttpHeaders(allowMutableHeadersAndFilterOnIOS: true)}");
+          setHttpHeaders({_authorizationHeader: 'Bearer $_customAccessToken'}, allowMutableHeadersAndFilterOnIOS: true);
+        },
+        child: Icon(Icons.refresh),
+      ),
+    );
+  }
+
+  String _getRandomAccessToken() => _random.nextInt(1000000000).toString();
+
+  void onStyleLoadedCallback() {}
+}
+
+final _localServerAddress = InternetAddress.loopbackIPv4.host;
+const _localServerPort = 8000;
+const _authorizationHeader = 'Authorization';
+final _customStyle = jsonEncode({
+  "version": 8,
+  "name": "local",
+  "sources": {
+    "local": {
+      "type": "vector",
+      "tiles": ["http://$_localServerAddress:$_localServerPort/{z}/{x}/{y}.pbf"]
+    }
+  },
+  "sprite": "http://$_localServerAddress:$_localServerPort/sprites",
+  "glyphs":
+      "http://$_localServerAddress:$_localServerPort/fonts/{fontstack}/{range}.pbf?key={key}",
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {"background-color": "rgba(0, 255, 0, 1)"}
+    },
+    {
+      "id": "water",
+      "type": "fill",
+      "source": "local",
+      "source-layer": "water",
+      "paint": {"fill-color": "rgb(158,189,255)"}
+    }
+  ],
+  "id": "local"
+});

--- a/example/lib/http_headers.dart
+++ b/example/lib/http_headers.dart
@@ -40,7 +40,8 @@ class _HttpHeadersState extends State<HttpHeaders> {
 
     _random = Random();
     _customAccessToken = _getRandomAccessToken();
-    setHttpHeaders({_authorizationHeader: 'Bearer $_customAccessToken'}, allowMutableHeadersAndFilterOnIOS: true);
+    setHttpHeaders({_authorizationHeader: 'Bearer $_customAccessToken'},
+        allowMutableHeadersAndFilterOnIOS: true);
 
     HttpServer.bind(_localServerAddress, _localServerPort).then((server) {
       setState(() {
@@ -71,13 +72,14 @@ class _HttpHeadersState extends State<HttpHeaders> {
         request.response.close();
         return;
       } else if (request.uri.path.contains('.pbf') ||
-          request.uri.path.contains('sprites')) {        
+          request.uri.path.contains('sprites')) {
         request.response.statusCode = 200;
         request.response.close();
         return;
       }
     }
-    print("Unauthorized for ${request.uri.path}: Expected $_customAccessToken, got $authorizationHeader");
+    print(
+        "Unauthorized for ${request.uri.path}: Expected $_customAccessToken, got $authorizationHeader");
     request.response.statusCode = 401;
     request.response.close();
   }
@@ -94,18 +96,19 @@ class _HttpHeadersState extends State<HttpHeaders> {
         onMapCreated: _onMapCreated,
         initialCameraPosition: const CameraPosition(target: LatLng(0.0, 0.0)),
         onStyleLoadedCallback: onStyleLoadedCallback,
-        gestureRecognizers:
-                          <Factory<OneSequenceGestureRecognizer>>[
-                        Factory<OneSequenceGestureRecognizer>(
-                          () => EagerGestureRecognizer(),
-                        ),
-                      ].toSet(),
+        gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>[
+          Factory<OneSequenceGestureRecognizer>(
+            () => EagerGestureRecognizer(),
+          ),
+        ].toSet(),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
           _customAccessToken = _getRandomAccessToken();
-          print("Reported headers: ${await getHttpHeaders(allowMutableHeadersAndFilterOnIOS: true)}");
-          setHttpHeaders({_authorizationHeader: 'Bearer $_customAccessToken'}, allowMutableHeadersAndFilterOnIOS: true);
+          print(
+              "Reported headers: ${await getHttpHeaders(allowMutableHeadersAndFilterOnIOS: true)}");
+          setHttpHeaders({_authorizationHeader: 'Bearer $_customAccessToken'},
+              allowMutableHeadersAndFilterOnIOS: true);
         },
         child: Icon(Icons.refresh),
       ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,6 +15,7 @@ import 'annotation_order_maps.dart';
 import 'click_annotations.dart';
 import 'custom_marker.dart';
 import 'full_map.dart';
+import 'http_headers.dart';
 import 'layer.dart';
 import 'line.dart';
 import 'local_style.dart';
@@ -40,6 +41,7 @@ final List<ExamplePage> _allPages = <ExamplePage>[
   PlaceSourcePage(),
   LinePage(),
   LocalStylePage(),
+  HttpHeadersPage(),
   LayerPage(),
   PlaceCirclePage(),
   PlaceFillPage(),

--- a/ios/Classes/SwiftMapboxGlFlutterPlugin.swift
+++ b/ios/Classes/SwiftMapboxGlFlutterPlugin.swift
@@ -18,7 +18,10 @@ public class SwiftMapboxGlFlutterPlugin: NSObject, FlutterPlugin {
             case "setHttpHeaders":
                 guard let arguments = methodCall.arguments as? [String: Any],
                       let headers = arguments["headers"] as? [String: String],
-                      let allowMutableHeadersAndFilterOnIOS = arguments["allowMutableHeadersAndFilterOnIOS"] as? Bool                      
+                      let allowMutableHeadersAndFilterOnIOS =
+                      arguments[
+                          "allowMutableHeadersAndFilterOnIOS"
+                      ] as? Bool
                 else {
                     result(FlutterError(
                         code: "setHttpHeadersError",
@@ -26,7 +29,7 @@ public class SwiftMapboxGlFlutterPlugin: NSObject, FlutterPlugin {
                         details: nil
                     ))
                     return
-                }                
+                }
                 if allowMutableHeadersAndFilterOnIOS {
                     let filter = arguments["filter"] as? [String]
                     NSURLRequest.registerSwizzling()
@@ -35,11 +38,12 @@ public class SwiftMapboxGlFlutterPlugin: NSObject, FlutterPlugin {
                     let sessionConfig = URLSessionConfiguration.default
                     sessionConfig.httpAdditionalHeaders = headers // your headers here
                     MGLNetworkConfiguration.sharedManager.sessionConfiguration = sessionConfig
-                }                               
+                }
                 result(nil)
             case "getHttpHeaders":
                 guard let arguments = methodCall.arguments as? [String: Any],
-                      let allowMutableHeadersAndFilterOnIOS = arguments["allowMutableHeadersAndFilterOnIOS"] as? Bool
+                      let allowMutableHeadersAndFilterOnIOS =
+                      arguments["allowMutableHeadersAndFilterOnIOS"] as? Bool
                 else {
                     result(FlutterError(
                         code: "getHttpHeadersError",
@@ -51,7 +55,8 @@ public class SwiftMapboxGlFlutterPlugin: NSObject, FlutterPlugin {
                 if allowMutableHeadersAndFilterOnIOS {
                     result(NSURLRequest.getHttpHeaders())
                 } else {
-                    result(MGLNetworkConfiguration.sharedManager.sessionConfiguration.httpAdditionalHeaders)
+                    result(MGLNetworkConfiguration.sharedManager.sessionConfiguration
+                        .httpAdditionalHeaders)
                 }
                 result(nil)
             case "installOfflineMapTiles":

--- a/ios/Classes/Swizzles.h
+++ b/ios/Classes/Swizzles.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+#import <Mapbox/MGLMapView.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSURLRequest (HttpHeaders)
++ (void) registerSwizzling;
++ (void) setHttpHeaders:(NSDictionary<NSString*,NSString*>* _Nullable)headers forFilter:(NSArray<NSString*>* _Nullable)filter;
++ (NSDictionary<NSString*,NSString*>* _Nullable) getHttpHeaders;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Classes/Swizzles.m
+++ b/ios/Classes/Swizzles.m
@@ -1,0 +1,64 @@
+#import "Swizzles.h"
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+static NSDictionary* _Nullable _headers = nil;
+static NSArray* _Nullable _filter = nil;
+static NSDictionary* _Nullable _usedHeaders = nil;
+ 
+@implementation NSURLRequest (HttpHeaders)
+
++ (void) registerSwizzling {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSLog(@"Swizzle: registering NSURLRequest.requestWithURL override");
+
+        Class targetClass = [NSURLRequest class];
+        Method oldMethod = class_getClassMethod(targetClass, @selector(requestWithURL:));
+        Method newMethod = class_getClassMethod(targetClass, @selector(__swizzle_requestWithURL:));
+        method_exchangeImplementations(oldMethod, newMethod);
+    });
+}
+
++ (NSURLRequest*) __swizzle_requestWithURL:(NSURL*)url {
+    NSLog(@"Swizzle: calling override for NSURLRequest.requestWithURL");
+
+    NSMutableURLRequest* req = (NSMutableURLRequest *)[NSMutableURLRequest __swizzle_requestWithURL:url];
+    NSArray<NSString*>* stack = [NSThread callStackSymbols];
+    if(![url.scheme isEqualToString:@"ws"] && [stack count] >= 2 && [stack[1] containsString:@"Mapbox"] == YES) {
+        NSDictionary<NSString*,NSString*>* headers = _headers;
+        NSArray<NSString*>* filter = _filter;
+        if (_headers != nil) {       
+            if (_filter != nil) {
+                for (NSString* pattern in filter) {
+                    if ([url.absoluteString containsString:pattern] == YES) {
+                        for (NSString* key in headers) {
+                            [req setValue: headers[key] forHTTPHeaderField:key];
+                        }
+                        _usedHeaders = headers;
+                        return req;
+                    }
+                }        
+            } else {
+                for (NSString* key in headers) {
+                    [req setValue: headers[key] forHTTPHeaderField:key];
+                }
+                _usedHeaders = headers;
+            }
+        }
+    }
+
+    return req;
+}
+
++ (void) setHttpHeaders:(NSDictionary<NSString*,NSString*>* _Nullable)headers forFilter:(NSArray<NSString*>* _Nullable) filter {
+    _headers = headers;
+    _filter = filter;
+}
+
++ (NSDictionary<NSString*,NSString*> *) getHttpHeaders {
+    return _usedHeaders;
+}
+
+@end

--- a/lib/mapbox_gl.dart
+++ b/lib/mapbox_gl.dart
@@ -6,6 +6,7 @@ library mapbox_gl;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 

--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -35,40 +35,46 @@ Future<dynamic> setOffline(
 /// Sets custom header specified in [headers] for uris which contain strings,
 /// specified in [filter].
 ///
-/// If [filter] is omitted, headers are applied to all requests. 
+/// If [filter] is omitted, headers are applied to all requests.
 /// An non-null empty [filter] will result in no headers being applied to any request.
-/// 
+///
 /// On iOS by default changes to headers are not possible once they are set and
 /// filters can't be applied as well.
 /// You can use [allowMutableHeadersAndFilterOnIOS] to be able to change headers (e.g. when access
 /// token is invalidated) and filters to prevent leaking authentication headers. This enforces the
 /// use of swizzling and should be used with great care, since it swaps methods of exising classes
 /// and may change upon native SDK upgrade. Use with caution.
-Future<void> setHttpHeaders(Map<String, String> headers, {List<String>? filter, bool allowMutableHeadersAndFilterOnIOS = false}) {
+Future<void> setHttpHeaders(Map<String, String> headers,
+    {List<String>? filter, bool allowMutableHeadersAndFilterOnIOS = false}) {
   return _globalChannel.invokeMethod(
     'setHttpHeaders',
     <String, dynamic>{
       'headers': headers,
       'filter': filter,
-      'allowMutableHeadersAndFilterOnIOS': Platform.isIOS ? allowMutableHeadersAndFilterOnIOS : false,
+      'allowMutableHeadersAndFilterOnIOS':
+          Platform.isIOS ? allowMutableHeadersAndFilterOnIOS : false,
     },
   );
 }
 
 /// Gets custom headers that are used in Mapbox queries.
 ///
-/// If [allowMutableHeadersAndFilterOnIOS] is used on iOS, headers are reported only after they are 
+/// If [allowMutableHeadersAndFilterOnIOS] is used on iOS, headers are reported only after they are
 /// actually used in a request. This provides a proven way of checking whether setting headers works
 /// and must be used the same way as [setHttpHeaders] is called as it involves swizzling. For more
 /// information look at [setHttpHeaders] documentation. Use with caution.
-Future<Map<String, String>?> getHttpHeaders({bool allowMutableHeadersAndFilterOnIOS = false}) async {
+Future<Map<String, String>?> getHttpHeaders(
+    {bool allowMutableHeadersAndFilterOnIOS = false}) async {
   final result = await _globalChannel.invokeMethod<Map<dynamic, dynamic>>(
     'getHttpHeaders',
     <String, dynamic>{
-      'allowMutableHeadersAndFilterOnIOS': Platform.isIOS ? allowMutableHeadersAndFilterOnIOS : false,
+      'allowMutableHeadersAndFilterOnIOS':
+          Platform.isIOS ? allowMutableHeadersAndFilterOnIOS : false,
     },
   );
-  return result?.map((key, value) => MapEntry<String, String>(key.toString(), value.toString())) ?? <String, String>{};
+  return result?.map((key, value) =>
+          MapEntry<String, String>(key.toString(), value.toString())) ??
+      <String, String>{};
 }
 
 Future<List<OfflineRegion>> mergeOfflineRegions(

--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -32,13 +32,43 @@ Future<dynamic> setOffline(
       },
     );
 
-Future<void> setHttpHeaders(Map<String, String> headers) {
+/// Sets custom header specified in [headers] for uris which contain strings,
+/// specified in [filter].
+///
+/// If [filter] is omitted, headers are applied to all requests. 
+/// An non-null empty [filter] will result in no headers being applied to any request.
+/// 
+/// On iOS by default changes to headers are not possible once they are set and
+/// filters can't be applied as well.
+/// You can use [allowMutableHeadersAndFilterOnIOS] to be able to change headers (e.g. when access
+/// token is invalidated) and filters to prevent leaking authentication headers. This enforces the
+/// use of swizzling and should be used with great care, since it swaps methods of exising classes
+/// and may change upon native SDK upgrade. Use with caution.
+Future<void> setHttpHeaders(Map<String, String> headers, {List<String>? filter, bool allowMutableHeadersAndFilterOnIOS = false}) {
   return _globalChannel.invokeMethod(
     'setHttpHeaders',
     <String, dynamic>{
       'headers': headers,
+      'filter': filter,
+      'allowMutableHeadersAndFilterOnIOS': Platform.isIOS ? allowMutableHeadersAndFilterOnIOS : false,
     },
   );
+}
+
+/// Gets custom headers that are used in Mapbox queries.
+///
+/// If [allowMutableHeadersAndFilterOnIOS] is used on iOS, headers are reported only after they are 
+/// actually used in a request. This provides a proven way of checking whether setting headers works
+/// and must be used the same way as [setHttpHeaders] is called as it involves swizzling. For more
+/// information look at [setHttpHeaders] documentation. Use with caution.
+Future<Map<String, String>?> getHttpHeaders({bool allowMutableHeadersAndFilterOnIOS = false}) async {
+  final result = await _globalChannel.invokeMethod<Map<dynamic, dynamic>>(
+    'getHttpHeaders',
+    <String, dynamic>{
+      'allowMutableHeadersAndFilterOnIOS': Platform.isIOS ? allowMutableHeadersAndFilterOnIOS : false,
+    },
+  );
+  return result?.map((key, value) => MapEntry<String, String>(key.toString(), value.toString())) ?? <String, String>{};
 }
 
 Future<List<OfflineRegion>> mergeOfflineRegions(

--- a/mapbox_gl_platform_interface/lib/src/view_wrappers.dart
+++ b/mapbox_gl_platform_interface/lib/src/view_wrappers.dart
@@ -32,35 +32,54 @@ class TextureAndroidViewControllerWrapper
 
   final TextureAndroidViewController _controller;
 
-  @override
+  // @override
   PointTransformer get pointTransformer => _controller.pointTransformer;
   set pointTransformer(PointTransformer transformer) =>
       _controller.pointTransformer = transformer;
 
-  @override
+  // @override
   void addOnPlatformViewCreatedListener(PlatformViewCreatedCallback listener) =>
       _controller.addOnPlatformViewCreatedListener(listener);
 
-  @override
-  bool get awaitingCreation => _controller.awaitingCreation;
+  /// Beginning with flutter 3, [_controller.awaitingCreation] should be called.
+  ///
+  /// A false value is returned in order to consolidate usage with flutter 2.
+  /// A false return value does not necessarily indicate that the Future
+  /// returned by create has completed, only that creation has been started.
+  // @override
+  bool awaitingCreation = true;
 
-  @override
+  // @override
   Future<void> clearFocus() => _controller.clearFocus();
 
-  @override
-  Future<void> create({Size? size}) => _controller.create(size: size);
+  /// Beginning with flutter 3, [_controller.create] with [size] should be called.
+  ///
+  /// size is the view's initial size in logical pixel. size can be omitted
+  /// if the concrete implementation doesn't require an initial size to create
+  /// the platform view.
+  Future<void> create({Size? size}) async {
+    await _controller.create();
+    awaitingCreation = false;
+    if (size != null) {
+      await _controller.setSize(size);
+    }
+  }
 
-  @override
+  /// Beginning with flutter 3, [_controller.createdCallbacks] should be called.
+  ///
+  /// This is for testing purposes only and is not relevant for production code.
+  // @override
   // ignore: invalid_use_of_visible_for_testing_member
-  List<PlatformViewCreatedCallback> get createdCallbacks =>
-      _controller.createdCallbacks;
+  List<PlatformViewCreatedCallback> get createdCallbacks => [];
 
-  @override
+  // @override
   Future<void> dispatchPointerEvent(PointerEvent event) =>
       _controller.dispatchPointerEvent(event);
 
-  @override
-  //! workaround for flutter 3.0
+  /// Beginning with flutter 3, disposal is called to soon, resulting in crashes.
+  ///
+  /// This is a workaround for users to be able to use this plugin with flutter 3.
+  // ignore: invalid_use_of_visible_for_testing_member
   Future<void> dispose() {
     //? instead of this
     // _controller.dispose();
@@ -69,32 +88,40 @@ class TextureAndroidViewControllerWrapper
     return Future(() {});
   }
 
-  @override
+  // @override
   bool get isCreated => _controller.isCreated;
 
-  @override
+  // @override
   void removeOnPlatformViewCreatedListener(
           PlatformViewCreatedCallback listener) =>
       _controller.removeOnPlatformViewCreatedListener(listener);
 
-  @override
+  // @override
   Future<void> sendMotionEvent(AndroidMotionEvent event) =>
       _controller.sendMotionEvent(event);
 
-  @override
+  // @override
   Future<void> setLayoutDirection(TextDirection layoutDirection) =>
       _controller.setLayoutDirection(layoutDirection);
 
-  @override
-  Future<void> setOffset(Offset off) => _controller.setOffset(off);
+  /// Beginning with flutter 3, [_controller.setOffset(off)] should be called.
+  ///
+  /// off is the view's new offset in logical pixel.
+  /// On Android, this allows the Android native view to draw the a11y highlights
+  /// in the same location on the screen as the platform view widget in the Flutter framework.
+  // @override
+  Future<void> setOffset(Offset off) => Future(() => {});
 
-  @override
-  Future<Size> setSize(Size size) => _controller.setSize(size);
+  // @override
+  Future<Size> setSize(Size size) async {
+    await _controller.setSize(size);
+    return size;
+  }
 
-  @override
+  // @override
   int? get textureId => _controller.textureId;
 
-  @override
+  // @override
   int get viewId => _controller.viewId;
 }
 
@@ -291,7 +318,7 @@ class _CopyPastedAndroidPlatformView extends LeafRenderObjectWidget {
   @override
   void updateRenderObject(
       BuildContext context, RenderAndroidView renderObject) {
-    renderObject.controller = controller;
+    //renderObject.controller = controller;
     renderObject.hitTestBehavior = hitTestBehavior;
     renderObject.updateGestureRecognizers(gestureRecognizers);
     renderObject.clipBehavior = clipBehavior;


### PR DESCRIPTION
This PR improves setting custom http headers with each tile request in order to support an authentication layer for protected custom resources.

It solves two problems:
- introduction of filters
- enabling headers to change in time on iOS.

Filtering feature prevents the user from leaking protected headers to resources which are not protected (and controlled by someone else). It is an optional parameters and passing null will cause headers to be appended to each request, so functionality stays as is. Passing a filter will cause appending headers only to requests, which contain filter content in URLs. Passing an empty filter will cause that no headers are appended to requests.

Mutable headers is an iOS issue. Setting headers at startup works, but setting them the second time (e.g. when access token invalidates) does not work. The proposed solution involves swizzling and because of that extra documentation was added to make sure end-users understand the risks when using this approach. That's why it is opt-in.
An additional method for checking previously set headers state was added to allow easy checking, whether setting headers works, since swizzling can break with SDK update.

An example with a local server was added to illustrate the behaviour of setting http headers client side and handling them server side.