### PR TITLE
Swift CGRect constructor for QueryRenderedFeaturesInRect

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -228,12 +228,12 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             }
             if let top = arguments["top"] as? Double,
                let left = arguments["left"] as? Double,
-               let width = arguments["width"] as? Double, 
+               let width = arguments["width"] as? Double,
                let height = arguments["height"] as? Double
             {
                 dump(arguments)
                 features = mapView.visibleFeatures(
-                    in: CGRect(x:left, y: top, width: width, height: height),
+                    in: CGRect(x: left, y: top, width: width, height: height),
                     styleLayerIdentifiers: styleLayerIdentifiers,
                     predicate: filterExpression
                 )

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -227,12 +227,13 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 )
             }
             if let top = arguments["top"] as? Double,
-               let bottom = arguments["bottom"] as? Double,
                let left = arguments["left"] as? Double,
-               let right = arguments["right"] as? Double
+               let width = arguments["width"] as? Double, 
+               let height = arguments["height"] as? Double
             {
+                dump(arguments)
                 features = mapView.visibleFeatures(
-                    in: CGRect(x: left, y: top, width: right, height: bottom),
+                    in: CGRect(x:left, y: top, width: width, height: height),
                     styleLayerIdentifiers: styleLayerIdentifiers,
                     predicate: filterExpression
                 )

--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -299,8 +299,13 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
         <String, Object?>{
           'left': rect.left,
           'top': rect.top,
+          //specific arguments needed for android rect function
           'right': rect.right,
           'bottom': rect.bottom,
+          //specific arguments needed for iOS rect function
+          'width': rect.width,
+          'height': rect.height,
+          //arguments for mapbox
           'layerIds': layerIds,
           'filter': filter,
         },


### PR DESCRIPTION
I believe that the conversion between the Dart Rect and the Swift CGRect was wrong, causing the CGRect to receive the bottom and left coordinate values where the height and width of the CGRect should be. CGRect constructs the rectangle from the top left corner, and the height and width double, as opposed to the java equivalent that receives the values for all four sides. 

See Issue #1203 
