### PR TITLE
Set non-null timeout in geolocate control options

### DIFF
--- a/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
+++ b/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
@@ -454,7 +454,7 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
     _removeGeolocateControl();
     _geolocateControl = GeolocateControl(
       GeolocateControlOptions(
-        positionOptions: PositionOptions(enableHighAccuracy: true),
+        positionOptions: PositionOptions(enableHighAccuracy: true, timeout: 6000),
         trackUserLocation: trackUserLocation,
         showAccuracyCircle: true,
         showUserLocation: true,


### PR DESCRIPTION
Passing `PositionOptions(enableHighAccuracy: true)` in dart code, is equivalent to `{ enableHighAccuracy: true, timeout: null, maximumAge: null }` in javascript, not `{ enableHighAccuracy: true }`, as it would be expected.

The consequence is that, by defaut, a `timeout` of `null` will be used when calling `watchPosition()` which results in most events being rejected.

To avoid this, I have set a value of 6000 ms, like in the geolocate_control.js file.