### PR TITLE
Setting style as a json object directly for web

### DIFF
--- a/mapbox_gl_web/lib/mapbox_gl_web.dart
+++ b/mapbox_gl_web/lib/mapbox_gl_web.dart
@@ -1,6 +1,7 @@
 library mapbox_gl_web;
 
 import 'dart:async';
+import 'dart:convert';
 // FIXED HERE: https://github.com/dart-lang/linter/pull/1985
 // ignore_for_file: avoid_web_libraries_in_flutter
 import 'dart:html';
@@ -21,6 +22,7 @@ import 'package:mapbox_gl_platform_interface/mapbox_gl_platform_interface.dart';
 import 'package:mapbox_gl_dart/mapbox_gl_dart.dart' hide Point, Source;
 import 'package:mapbox_gl_dart/mapbox_gl_dart.dart' as mapbox show Point;
 import 'package:image/image.dart' hide Point;
+import 'package:js/js_util.dart' as jsUtil;
 import 'package:mapbox_gl_web/src/layer_tools.dart';
 
 part 'src/convert.dart';

--- a/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
+++ b/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
@@ -641,7 +641,13 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
     }
     _interactiveFeatureLayerIds.clear();
 
-    _map.setStyle(styleString);
+    try {
+      final styleJson = jsonDecode(styleString ?? '');
+      final styleJsObject = jsUtil.jsify(styleJson);
+      _map.setStyle(styleJsObject);
+    } catch(_) {
+      _map.setStyle(styleString);
+    }
     // catch style loaded for later style changes
     if (_mapReady) {
       _map.once("styledata", _onStyleLoaded);


### PR DESCRIPTION
This PR enabled users to set style as a json object directly in flutter for Web.

This is already supported by the underlying mapbox_gl_dart package, the usage of it in this package is corrected.