### PR TITLE
Fix release mode web map animation

### DIFF
--- a/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
+++ b/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
@@ -199,21 +199,19 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
       {Duration? duration}) async {
     final cameraOptions = Convert.toCameraOptions(cameraUpdate, _map);
 
-    final around = getProperty(cameraOptions, 'around');
-    final bearing = getProperty(cameraOptions, 'bearing');
-    final center = getProperty(cameraOptions, 'center');
-    final pitch = getProperty(cameraOptions, 'pitch');
-    final zoom = getProperty(cameraOptions, 'zoom');
+    final bearing = cameraOptions.bearing;
+    final center = cameraOptions.center;
+    final pitch = cameraOptions.pitch;
+    final zoom = cameraOptions.zoom;
 
     _map.flyTo({
-      if (around.jsObject != null) 'around': around,
       if (bearing != null) 'bearing': bearing,
-      if (center.jsObject != null) 'center': center,
+      if (center != null && center.jsObject != null)
+        'center': [center.lng, center.lat],
       if (pitch != null) 'pitch': pitch,
       if (zoom != null) 'zoom': zoom,
       if (duration != null) 'duration': duration.inMilliseconds,
     });
-
     return true;
   }
 


### PR DESCRIPTION
This is caused by minify on flutter release mode, app can't access property by name because is changed. Issue is described here:
https://github.com/flutter-mapbox-gl/maps/issues/1264

This PR fixes this issue