### PR TITLE
Fix bugged ios CGRect parameters and git reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Please note that this project is community driven and is not an official Mapbox product.** 
 > 
-> We welcome [feedback](https://github.com/tobrun/flutter-mapbox-gl/issues) and contributions.
+> We welcome [feedback](https://github.com/flutter-mapbox-gl/maps/issues) and contributions.
 
 
 ## Table of contents
@@ -260,4 +260,4 @@ See the [documentation about this topic](doc/RUNNING_EXAMPLE_CODE.md)
 
 ## Contributing
 
-We welcome contributions to this repository! If you're interested in helping build this Mapbox-Flutter integration, please read [the contribution guide](https://github.com/tobrun/flutter-mapbox-gl/blob/master/CONTRIBUTING.md) to learn how to get started.
+We welcome contributions to this repository! If you're interested in helping build this Mapbox-Flutter integration, please read [the contribution guide](https://github.com/flutter-mapbox-gl/maps/blob/master/CONTRIBUTING.md) to learn how to get started.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,7 +29,7 @@ Update library version in `mapbox_gl_web/pubspec.yaml` in `mapbox_gl_platform_in
 Replace:
 mapbox_gl_platform_interface:
   git:
-    url: https://github.com/tobrun/flutter-mapbox-gl.git
+    url: https://github.com/flutter-mapbox-gl/maps.git
     path: mapbox_gl_platform_interface
 
 With:

--- a/android/src/main/java/com/mapbox/mapboxgl/MapBoxUtils.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapBoxUtils.java
@@ -32,7 +32,7 @@ abstract class MapBoxUtils {
           TAG,
           "Failed to find an Access Token in the Application meta-data. Maps may not load"
               + " correctly. Please refer to the installation guide at"
-              + " https://github.com/tobrun/flutter-mapbox-gl#mapbox-access-token for"
+              + " https://github.com/flutter-mapbox-gl/maps#mapbox-access-token for"
               + " troubleshooting advice."
               + e.getMessage());
     }

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -228,11 +228,11 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             }
             if let top = arguments["top"] as? Double,
                let bottom = arguments["bottom"] as? Double,
-               let left = arguments["left"] as? Double,
-               let right = arguments["right"] as? Double
+               let width = arguments["width"] as? Double, 
+               let height = arguments["height"] as? Double
             {
                 features = mapView.visibleFeatures(
-                    in: CGRect(x: left, y: top, width: right, height: bottom),
+                    in: CGRect(x:left, y: top, width: width, height: height),
                     styleLayerIdentifiers: styleLayerIdentifiers,
                     predicate: filterExpression
                 )

--- a/mapbox_gl_platform_interface/README.md
+++ b/mapbox_gl_platform_interface/README.md
@@ -1,1 +1,1 @@
-Contains the web platform implementation for the [Flutter Mapbox GL plugin](https://github.com/tobrun/flutter-mapbox-gl).
+Contains the web platform implementation for the [Flutter Mapbox GL plugin](https://github.com/flutter-mapbox-gl/maps).

--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -302,8 +302,13 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
         <String, Object?>{
           'left': rect.left,
           'top': rect.top,
+          //specific arguments needed for android rect function
           'right': rect.right,
           'bottom': rect.bottom,
+          //specific arguments needed for iOS rect function
+          'width': rect.width,
+          'height': rect.height,
+          //arguments for mapbox
           'layerIds': layerIds,
           'filter': filter,
         },

--- a/mapbox_gl_platform_interface/pubspec.yaml
+++ b/mapbox_gl_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mapbox_gl_platform_interface
 description: A common platform interface for the mapbox_gl plugin.
 version: 0.16.0
-homepage: https://github.com/tobrun/flutter-mapbox-gl
+homepage: https://github.com/flutter-mapbox-gl/maps
 
 dependencies:
   flutter:

--- a/mapbox_gl_web/README.md
+++ b/mapbox_gl_web/README.md
@@ -1,1 +1,1 @@
-Contains the web interfaces for the [Flutter Mapbox GL plugin](https://github.com/tobrun/flutter-mapbox-gl).
+Contains the web interfaces for the [Flutter Mapbox GL plugin](https://github.com/flutter-mapbox-gl/maps).

--- a/mapbox_gl_web/pubspec.yaml
+++ b/mapbox_gl_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mapbox_gl_web
 description: Web platform implementation of mapbox_gl
 version: 0.16.0
-homepage: https://github.com/tobrun/flutter-mapbox-gl
+homepage: https://github.com/flutter-mapbox-gl/maps
 
 flutter:
   plugin:
@@ -18,7 +18,7 @@ dependencies:
   meta: ^1.1.7
   mapbox_gl_platform_interface:
     git:
-      url: https://github.com/tobrun/flutter-mapbox-gl.git
+      url: https://github.com/flutter-mapbox-gl/maps.git
       path: mapbox_gl_platform_interface
   mapbox_gl_dart: ^0.2.1
   image: '>=3.0.0 <5.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,18 @@
 name: mapbox_gl
 description: A Flutter plugin for integrating Mapbox Maps inside a Flutter application on Android, iOS and web platfroms.
 version: 0.16.0
-homepage: https://github.com/tobrun/flutter-mapbox-gl
+homepage: https://github.com/flutter-mapbox-gl/maps
 
 dependencies:
   flutter:
     sdk: flutter
   mapbox_gl_platform_interface:
     git:
-      url: https://github.com/tobrun/flutter-mapbox-gl.git
+      url: https://github.com/flutter-mapbox-gl/maps.git
       path: mapbox_gl_platform_interface
   mapbox_gl_web:
     git:
-      url: https://github.com/tobrun/flutter-mapbox-gl.git
+      url: https://github.com/flutter-mapbox-gl/maps.git
       path: mapbox_gl_web
   collection: ^1.15.0
 


### PR DESCRIPTION
The conversion between the Dart Rect and the Swift CGRect was wrong, causing the CGRect to receive the bottom and left coordinate values where the height and width of the CGRect should be. CGRect constructs the rectangle from the top left corner, and the height and width double, as opposed to the java equivalent that receives the values for all four sides.


See Issue #1203 and my previous PR for this #1208

Updated the foreign references from @tobrun's old repository to this repository, as they seem to be messing up the pubspec references for git imports. There is an outdated approved PR with these changes that was closed by the bot #891. 
