### PR TITLE
Fix bugged ios CGRect parameters and git reference

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -226,17 +226,17 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                     predicate: filterExpression
                 )
             }
-            if let top = arguments["top"] as? Double,
-               let bottom = arguments["bottom"] as? Double,
+            if let top = arguments["top"] as? Double,               
                let left = arguments["left"] as? Double,
-               let right = arguments["right"] as? Double
+               let width = arguments["width"] as? Double,
+               let height = arguments["height"] as? Double
             {
+                dump(arguments)
                 features = mapView.visibleFeatures(
-                    in: CGRect(x: left, y: top, width: right, height: bottom),
+                    in: CGRect(x: left, y: top, width: width, height: height),
                     styleLayerIdentifiers: styleLayerIdentifiers,
                     predicate: filterExpression
                 )
-            }
             var featuresJson = [String]()
             for feature in features {
                 let dictionary = feature.geoJSONDictionary()

--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -302,8 +302,13 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
         <String, Object?>{
           'left': rect.left,
           'top': rect.top,
+          //specific arguments needed for android rect function
           'right': rect.right,
           'bottom': rect.bottom,
+          //specific arguments needed for iOS rect function
+          'width': rect.width,
+          'height': rect.height,
+          //arguments for mapbox
           'layerIds': layerIds,
           'filter': filter,
         },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,15 @@
 name: mapbox_gl
 description: A Flutter plugin for integrating Mapbox Maps inside a Flutter application on Android, iOS and web platfroms.
 version: 0.16.0
-homepage: https://github.com/tobrun/flutter-mapbox-gl
+homepage: https://github.com/flutter-mapbox-gl/maps
 
 dependencies:
   flutter:
     sdk: flutter
   mapbox_gl_platform_interface:
-    git:
-      url: https://github.com/tobrun/flutter-mapbox-gl.git
-      path: mapbox_gl_platform_interface
+      path: ./mapbox_gl_platform_interface
   mapbox_gl_web:
-    git:
-      url: https://github.com/tobrun/flutter-mapbox-gl.git
-      path: mapbox_gl_web
+      path: ./mapbox_gl_web
   collection: ^1.15.0
 
 dependency_overrides:


### PR DESCRIPTION
The conversion between the Dart Rect and the Swift CGRect was wrong, causing the CGRect to receive the bottom and left coordinate values where the height and width of the CGRect should be. CGRect constructs the rectangle from the top left corner, and the height and width double, as opposed to the java equivalent that receives the values for all four sides.

See Issue https://github.com/flutter-mapbox-gl/maps/issues/1203 and my previous PR for this https://github.com/flutter-mapbox-gl/maps/pull/1208

Updated the foreign references from @tobrun's old repository to this repository, as they seem to be messing up the pubspec references for git imports. There is an outdated approved PR with these changes that was closed by the bot https://github.com/flutter-mapbox-gl/maps/pull/891.