### PR TITLE
Set explicit default values in GeolocateControlOptions

### DIFF
--- a/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
+++ b/mapbox_gl_web/lib/src/mapbox_web_gl_platform.dart
@@ -454,7 +454,7 @@ class MapboxWebGlPlatform extends MapboxGlPlatform
     _removeGeolocateControl();
     _geolocateControl = GeolocateControl(
       GeolocateControlOptions(
-        positionOptions: PositionOptions(enableHighAccuracy: true),
+        positionOptions: PositionOptions(enableHighAccuracy: true, timeout: double.infinity, maximumAge: 0),
         trackUserLocation: trackUserLocation,
         showAccuracyCircle: true,
         showUserLocation: true,


### PR DESCRIPTION
As a follow-up of https://github.com/flutter-mapbox-gl/maps/pull/1260, set default values for `timeout` and `maximumAge`, with respect to https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition#syntax.