### PR TITLE
Added the namespace property in build.gradle if the field is necessary.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,10 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 31
     ndkVersion "20.1.5948944"
+    // Condition for namespace compatibility in AGP 8
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.mapbox.mapboxgl'
+    }
 
     defaultConfig {
         minSdkVersion 20


### PR DESCRIPTION
This PR branch provide the package namespace if the AGP is equal or higher then 8.

Please Review: @AAverin 