### PR TITLE
Google Play Services 21 IncompatibleClassChangeError FusedLocationProviderClient

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,13 +30,19 @@ rootProject.allprojects {
                 password = token
             }
         }
+        // Has to be forced as this is the latest mapbox-core-android supports
+        configurations.all {
+            resolutionStrategy {
+                force "com.google.android.gms:play-services-location:20.0.0"
+            }
+        }
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
     ndkVersion "20.1.5948944"
 
     defaultConfig {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -69,12 +69,4 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.0-alpha4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-alpha4'
-    constraints {
-        implementation('com.google.android.gms:play-services-location') {
-            version {
-                strictly "16.0.0"
-            }
-            because 'location: 4.2.3 does not specify version play-services-location'
-            }
-    }
 }


### PR DESCRIPTION
**Reasoning** 

Google have introduced some breaking changes in Google Play Services 21.0.1 turning some classes into interfaces.
This results in exceptions in production, especially if other location libraries like `flutter location` are used:
```
java.lang.IncompatibleClassChangeError: Found interface com.google.android.gms.location.FusedLocationProviderClient, but class was expected (declaration of 'com.google.android.gms.location.FusedLocationProviderClient'
```

Unfortunately because mapbox-core-andorid is no longer supported, it won't be migrated to 21+ implementation.

The best we can do is to pin play services to 20.0.0 in the library. This fixes exceptions in production builds, at least for `example` app.

Likely some changes in the project that uses this library will have to be made to make things work.

**What changed**

Force google play-services-location to 20.0.0 as this is the latest mapbox-core-android can support due to https://github.com/mapbox/mapbox-events-android/issues/577