### PR TITLE
Missing enableInteraction argument

### DIFF
--- a/lib/src/annotation_manager.dart
+++ b/lib/src/annotation_manager.dart
@@ -44,7 +44,8 @@ abstract class AnnotationManager<T extends Annotation> {
       final layerId = _makeLayerId(i);
       controller.addGeoJsonSource(layerId, buildFeatureCollection([]),
           promoteId: "id");
-      controller.addLayer(layerId, layerId, allLayerProperties[i]);
+      controller.addLayer(layerId, layerId, allLayerProperties[i],
+          enableInteraction: enableInteraction);
     }
 
     if (onTap != null) {
@@ -58,7 +59,8 @@ abstract class AnnotationManager<T extends Annotation> {
   Future<void> _rebuildLayers() async {
     for (var i = 0; i < allLayerProperties.length; i++) {
       final layerId = _makeLayerId(i);
-      await controller.addLayer(layerId, layerId, allLayerProperties[i]);
+      await controller.addLayer(layerId, layerId, allLayerProperties[i],
+          enableInteraction: enableInteraction);
     }
   }
 


### PR DESCRIPTION
**Summary of Changes:**

I added the `enableInteraction` parameter to the AnnotationManager class initial method and _rebuildLayers method. By this way, we allow updating the `enableInteraction` value based on annotationConsumeTapEvents.

**Currently:**
We can't disable interaction for symbolManager (I tried this way: `annotationConsumeTapEvents: const [AnnotationType.line, AnnotationType.fill, AnnotationType.circle]`).

Please help me review it @felix-ht .