### PR TITLE
Use Object.hash instead of hashValues

### DIFF
--- a/mapbox_gl_platform_interface/lib/src/camera.dart
+++ b/mapbox_gl_platform_interface/lib/src/camera.dart
@@ -80,7 +80,7 @@ class CameraPosition {
   }
 
   @override
-  int get hashCode => hashValues(bearing, target, tilt, zoom);
+  int get hashCode => Object.hashAll([bearing, target, tilt, zoom]);
 
   @override
   String toString() =>

--- a/mapbox_gl_platform_interface/lib/src/camera.dart
+++ b/mapbox_gl_platform_interface/lib/src/camera.dart
@@ -80,7 +80,7 @@ class CameraPosition {
   }
 
   @override
-  int get hashCode => Object.hashAll([bearing, target, tilt, zoom]);
+  int get hashCode => Object.hash(bearing, target, tilt, zoom);
 
   @override
   String toString() =>

--- a/mapbox_gl_platform_interface/lib/src/location.dart
+++ b/mapbox_gl_platform_interface/lib/src/location.dart
@@ -14,7 +14,8 @@ class LatLng {
   /// The longitude is normalized to the half-open interval from -180.0
   /// (inclusive) to +180.0 (exclusive)
   const LatLng(double latitude, double longitude)
-      : latitude = (latitude < -90.0 ? -90.0 : (90.0 < latitude ? 90.0 : latitude)),
+      : latitude =
+            (latitude < -90.0 ? -90.0 : (90.0 < latitude ? 90.0 : latitude)),
         longitude = (longitude + 180.0) % 360.0 - 180.0;
 
   /// The latitude in degrees between -90.0 and 90.0, both inclusive.
@@ -99,7 +100,9 @@ class LatLngBounds {
 
   @override
   bool operator ==(Object o) {
-    return o is LatLngBounds && o.southwest == southwest && o.northeast == northeast;
+    return o is LatLngBounds &&
+        o.southwest == southwest &&
+        o.northeast == northeast;
   }
 
   @override

--- a/mapbox_gl_platform_interface/lib/src/location.dart
+++ b/mapbox_gl_platform_interface/lib/src/location.dart
@@ -14,8 +14,7 @@ class LatLng {
   /// The longitude is normalized to the half-open interval from -180.0
   /// (inclusive) to +180.0 (exclusive)
   const LatLng(double latitude, double longitude)
-      : latitude =
-            (latitude < -90.0 ? -90.0 : (90.0 < latitude ? 90.0 : latitude)),
+      : latitude = (latitude < -90.0 ? -90.0 : (90.0 < latitude ? 90.0 : latitude)),
         longitude = (longitude + 180.0) % 360.0 - 180.0;
 
   /// The latitude in degrees between -90.0 and 90.0, both inclusive.
@@ -53,7 +52,7 @@ class LatLng {
   }
 
   @override
-  int get hashCode => hashValues(latitude, longitude);
+  int get hashCode => Object.hashAll([latitude, longitude]);
 }
 
 /// A latitude/longitude aligned rectangle.
@@ -100,13 +99,11 @@ class LatLngBounds {
 
   @override
   bool operator ==(Object o) {
-    return o is LatLngBounds &&
-        o.southwest == southwest &&
-        o.northeast == northeast;
+    return o is LatLngBounds && o.southwest == southwest && o.northeast == northeast;
   }
 
   @override
-  int get hashCode => hashValues(southwest, northeast);
+  int get hashCode => Object.hashAll([southwest, northeast]);
 }
 
 /// A geographical area representing a non-aligned quadrilateral
@@ -164,7 +161,7 @@ class LatLngQuad {
   }
 
   @override
-  int get hashCode => hashValues(topLeft, topRight, bottomRight, bottomLeft);
+  int get hashCode => Object.hashAll([topLeft, topRight, bottomRight, bottomLeft]);
 }
 
 /// User's observed location

--- a/mapbox_gl_platform_interface/lib/src/location.dart
+++ b/mapbox_gl_platform_interface/lib/src/location.dart
@@ -52,7 +52,7 @@ class LatLng {
   }
 
   @override
-  int get hashCode => Object.hashAll([latitude, longitude]);
+  int get hashCode => Object.hash(latitude, longitude);
 }
 
 /// A latitude/longitude aligned rectangle.
@@ -103,7 +103,7 @@ class LatLngBounds {
   }
 
   @override
-  int get hashCode => Object.hashAll([southwest, northeast]);
+  int get hashCode => Object.hash(southwest, northeast);
 }
 
 /// A geographical area representing a non-aligned quadrilateral
@@ -161,7 +161,7 @@ class LatLngQuad {
   }
 
   @override
-  int get hashCode => Object.hashAll([topLeft, topRight, bottomRight, bottomLeft]);
+  int get hashCode => Object.hash(topLeft, topRight, bottomRight, bottomLeft);
 }
 
 /// User's observed location

--- a/mapbox_gl_platform_interface/lib/src/ui.dart
+++ b/mapbox_gl_platform_interface/lib/src/ui.dart
@@ -29,8 +29,7 @@ class MapboxStyles {
   /// Satellite Streets: Global satellite and aerial imagery with unobtrusive labels. Using this
   /// constant means your map style will always use the latest version and may change as we
   /// improve the style.
-  static const String SATELLITE_STREETS =
-      "mapbox://styles/mapbox/satellite-streets-v11";
+  static const String SATELLITE_STREETS = "mapbox://styles/mapbox/satellite-streets-v11";
 
   /// Traffic Day: Color-coded roads based on live traffic congestion data. Traffic data is currently
   /// available in
@@ -129,8 +128,7 @@ class MinMaxZoomPreference {
   final double? maxZoom;
 
   /// Unbounded zooming.
-  static const MinMaxZoomPreference unbounded =
-      MinMaxZoomPreference(null, null);
+  static const MinMaxZoomPreference unbounded = MinMaxZoomPreference(null, null);
 
   dynamic toJson() => <dynamic>[minZoom, maxZoom];
 
@@ -143,7 +141,7 @@ class MinMaxZoomPreference {
   }
 
   @override
-  int get hashCode => hashValues(minZoom, maxZoom);
+  int get hashCode => Object.hashAll([minZoom, maxZoom]);
 
   @override
   String toString() {

--- a/mapbox_gl_platform_interface/lib/src/ui.dart
+++ b/mapbox_gl_platform_interface/lib/src/ui.dart
@@ -29,7 +29,8 @@ class MapboxStyles {
   /// Satellite Streets: Global satellite and aerial imagery with unobtrusive labels. Using this
   /// constant means your map style will always use the latest version and may change as we
   /// improve the style.
-  static const String SATELLITE_STREETS = "mapbox://styles/mapbox/satellite-streets-v11";
+  static const String SATELLITE_STREETS =
+      "mapbox://styles/mapbox/satellite-streets-v11";
 
   /// Traffic Day: Color-coded roads based on live traffic congestion data. Traffic data is currently
   /// available in
@@ -128,7 +129,8 @@ class MinMaxZoomPreference {
   final double? maxZoom;
 
   /// Unbounded zooming.
-  static const MinMaxZoomPreference unbounded = MinMaxZoomPreference(null, null);
+  static const MinMaxZoomPreference unbounded =
+      MinMaxZoomPreference(null, null);
 
   dynamic toJson() => <dynamic>[minZoom, maxZoom];
 

--- a/mapbox_gl_platform_interface/lib/src/ui.dart
+++ b/mapbox_gl_platform_interface/lib/src/ui.dart
@@ -141,7 +141,7 @@ class MinMaxZoomPreference {
   }
 
   @override
-  int get hashCode => Object.hashAll([minZoom, maxZoom]);
+  int get hashCode => Object.hash(minZoom, maxZoom);
 
   @override
   String toString() {

--- a/mapbox_gl_platform_interface/pubspec.yaml
+++ b/mapbox_gl_platform_interface/pubspec.yaml
@@ -9,5 +9,5 @@ dependencies:
   meta: ^1.0.5
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
   flutter: ">=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,6 @@ flutter:
         default_package: mapbox_gl_web
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
   # Flutter versions prior to 1.10 did not support the flutter.plugin.platforms map.
   flutter: ">=2.0.0"


### PR DESCRIPTION
The new Flutter stable version (3.27.0) bumps the version of Dart, and the new version removed the function `hashValues` which breaks apps that just upgraded to Flutter 3.27.0.

It's recommended to move to `Object.hash`

https://github.com/flutter/flutter/pull/96109